### PR TITLE
Titlecase all string values

### DIFF
--- a/custom_components/electrolux_status/sensor.py
+++ b/custom_components/electrolux_status/sensor.py
@@ -35,8 +35,10 @@ class ElectroluxSensor(ElectroluxEntity, SensorEntity):
         value = self.extract_value()
         if value is not None and self.unit == UnitOfTime.SECONDS:
             value = time_seconds_to_minutes(value)
-        if isinstance(value, str) and "_" in value:
-            value = value.replace("_", " ").title()
+        if isinstance(value, str):
+            if "_" in value:
+                value = value.replace("_", " ")
+            value = value.title()
         if value is not None:
             self._cached_value = value
         else:


### PR DESCRIPTION
Very small fix for string values that do not contain an `_` ie: Appliance State has values of `OFF`, `RUNNING` but also `End Of Cycle` or `Ready To Start`.

Do you also have an idea of how you might want to handle certain values that are ideally enumerated like Program UID, or being able to override the entity names, and I guess maybe locatization? I am just asking as I am willing to contribute. I am guessing there will be a preference not to as it could be a maintenance nightmare.