### PR TITLE
Update `pyelectroluxocp` and provide base logger to OneAppApi

### DIFF
--- a/custom_components/electrolux_status/__init__.py
+++ b/custom_components/electrolux_status/__init__.py
@@ -43,7 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     password = entry.data.get(CONF_PASSWORD)
     language = languages.get(entry.data.get(CONF_LANGUAGE, DEFAULT_LANGUAGE), "eng")
 
-    client = pyelectroluxconnect_util.get_session(username, password, language)
+    client = pyelectroluxconnect_util.get_session(username, password, _LOGGER, language)
     coordinator = ElectroluxCoordinator(hass, client=client, renew_interval=renew_interval)
     if not await coordinator.async_login():
         raise Exception("Electrolux wrong credentials")

--- a/custom_components/electrolux_status/config_flow.py
+++ b/custom_components/electrolux_status/config_flow.py
@@ -109,7 +109,7 @@ class ElectroluxStatusFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def _test_credentials(self, username, password):
         """Return true if credentials is valid."""
         try:
-            client = pyelectroluxconnect_util.get_session(username, password)
+            client = pyelectroluxconnect_util.get_session(username, password, _LOGGER)
             await self.hass.async_add_executor_job(client.get_appliances_list)
             return True
         except Exception as inst:  # pylint: disable=broad-except

--- a/custom_components/electrolux_status/manifest.json
+++ b/custom_components/electrolux_status/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/albaintor/homeassistant_electrolux_status/issues",
   "requirements": [
-    "pyelectroluxocp==0.0.14"
+    "pyelectroluxocp==0.0.17"
   ],
   "ssdp": [],
   "version": "1.0.0",

--- a/custom_components/electrolux_status/pyelectroluxconnect_util.py
+++ b/custom_components/electrolux_status/pyelectroluxconnect_util.py
@@ -1,7 +1,8 @@
+from logging import Logger
 from pyelectroluxocp.oneAppApi import OneAppApi
 
 class pyelectroluxconnect_util:
     @staticmethod
-    def get_session(username, password, language ="eng") -> OneAppApi:
-        return OneAppApi(username, password)
+    def get_session(username, password, logger: Logger, language ="eng") -> OneAppApi:
+        return OneAppApi(username, password, logger=logger)
 


### PR DESCRIPTION
This will allow to enable `debug` logs only to the base project and it will log everything in `pyelectroluxocp` dependency too.
Added **retry** for all requests.

Debug logs from `pyelectroluxocp` will look something like so:
`DEBUG:homeassistant_electrolux_status.pyelectroluxocp.OneAppApi:get_appliance_state(), id: xxxxxxxxxxx:xxxxxx-xxxxxxxxxx, include_metadata: True`