### PR TITLE
Fixed number entity unit mismatch

### DIFF
--- a/custom_components/electrolux_status/entity.py
+++ b/custom_components/electrolux_status/entity.py
@@ -29,6 +29,12 @@ def time_seconds_to_minutes(seconds):
         return int(math.ceil((int(seconds) / 60)))
     return None
 
+def time_minutes_to_seconds(minutes):
+    if minutes is not None:
+        if minutes == -1:
+            return -1
+        return int(minutes) * 60
+    return None
 
 class ElectroluxEntity(CoordinatorEntity):
     appliance_status: ApplienceStatusResponse

--- a/custom_components/electrolux_status/number.py
+++ b/custom_components/electrolux_status/number.py
@@ -4,7 +4,7 @@ from homeassistant.const import UnitOfTime, UnitOfTemperature
 from pyelectroluxocp import OneAppApi
 
 from .const import NUMBER, DOMAIN
-from .entity import ElectroluxEntity, time_seconds_to_minutes
+from .entity import ElectroluxEntity, time_seconds_to_minutes, time_minutes_to_seconds
 import logging
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -64,6 +64,8 @@ class ElectroluxNumber(ElectroluxEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
+        if self.unit == UnitOfTime.SECONDS:
+            value = time_minutes_to_seconds(value)
         client: OneAppApi = self.api
         if self.entity_source:
             command = { self.entity_source: {self.entity_attr: value}}


### PR DESCRIPTION
When setting the start time on my dishwasher, I observed that the input value was treated as seconds while the number entity was in minutes. To resolve this, I converted the value from the entity to seconds to align it with the rest of the code. After implementing this fix, the start time could be set successfully