### PR TITLE
Fix setup issues

### DIFF
--- a/custom_components/electrolux_status/api.py
+++ b/custom_components/electrolux_status/api.py
@@ -501,6 +501,7 @@ class Appliance:
         def electrolux_entity_factory(
             name: str,
             entity_type: Platform | None,
+            entity_name: str,
             entity_attr: str,
             entity_source: str,
             capability: str,

--- a/custom_components/electrolux_status/button.py
+++ b/custom_components/electrolux_status/button.py
@@ -86,7 +86,7 @@ class ElectroluxButton(ElectroluxEntity, ButtonEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID to use for this entity."""
-        return f"{self.config_entry.entry_id}-{self.val_to_send}-{self.entity_name}-{self.entity_source}-{self.pnc_id}"
+        return f"{self.config_entry.entry_id}-{self.val_to_send}-{self.entity_attr}-{self.entity_source}-{self.pnc_id}"
 
     @property
     def name(self) -> str:

--- a/custom_components/electrolux_status/entity.py
+++ b/custom_components/electrolux_status/entity.py
@@ -84,7 +84,7 @@ class ElectroluxEntity(CoordinatorEntity):
         self.pnc_id = pnc_id
         self.unit = unit
         self.capability = capability
-        self.entity_id = f"{self.entity_domain}.{self.get_appliance.brand}_{self.get_appliance.name}_{self.entity_source}_{self.entity_name}"
+        self.entity_id = f"{self.entity_domain}.{self.get_appliance.brand}_{self.get_appliance.name}_{self.entity_source}_{self.entity_attr}"
         if catalog_entry:
             self.entity_registry_enabled_default = (
                 catalog_entry.entity_registry_enabled_default
@@ -103,7 +103,7 @@ class ElectroluxEntity(CoordinatorEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID to use for this entity."""
-        return f"{self.config_entry.entry_id}-{self.entity_name}-{self.entity_source or 'root'}-{self.pnc_id}"
+        return f"{self.config_entry.entry_id}-{self.entity_attr}-{self.entity_source or 'root'}-{self.pnc_id}"
 
     # Disabled this as this removes the value from display : there is no readonly property for entities
     # @property


### PR DESCRIPTION
Looks like the order of
https://github.com/albaintor/homeassistant_electrolux_status/pull/88 and https://github.com/albaintor/homeassistant_electrolux_status/pull/92 might have messed with the new `entity_name` 

This resolves that and restores to fix https://github.com/albaintor/homeassistant_electrolux_status/issues/94 and standardises the names