### PR TITLE
Use NumberDeviceClass for temprature readwrite

### DIFF
--- a/custom_components/electrolux_status/api.py
+++ b/custom_components/electrolux_status/api.py
@@ -196,6 +196,8 @@ class ElectroluxLibraryEntity:
         if not type_class:
             return None
         if type_class == "temperature":
+            if capability_def.get("access", None) == "readwrite":
+                return NumberDeviceClass.TEMPERATURE
             return SensorDeviceClass.TEMPERATURE
         return None
 

--- a/custom_components/electrolux_status/catalog_core.py
+++ b/custom_components/electrolux_status/catalog_core.py
@@ -97,7 +97,7 @@ CATALOG_BASE: dict[str, ElectroluxDevice] = {
         entity_registry_enabled_default=False,
     ),
     "ambientTemperatureC": ElectroluxDevice(
-        capability_info={"access": "read","type": "number"},
+        capability_info={"access": "read", "type": "number"},
         device_class=SensorDeviceClass.TEMPERATURE,
         unit=UnitOfTemperature.CELSIUS,
         entity_category=None,
@@ -217,7 +217,7 @@ CATALOG_BASE: dict[str, ElectroluxDevice] = {
         unit=None,
         entity_category=None,
         entity_icon="mdi:house",
-        entity_icons_value_map= {
+        entity_icons_value_map={
             "OFF": "mdi:power-off",
             "ON": "mdi:power-on",
             "START": "mdi:play",
@@ -225,7 +225,7 @@ CATALOG_BASE: dict[str, ElectroluxDevice] = {
             "PAUSE": "mdi:pause",
             "RESUME": "mdi:play-pause",
         },
-        entity_value_named = True
+        entity_value_named=True,
     ),
     "extraCavity/alerts": ElectroluxDevice(
         capability_info={
@@ -687,7 +687,7 @@ CATALOG_BASE: dict[str, ElectroluxDevice] = {
             "min": 0,
             "step": 5.0,
         },
-        device_class=SensorDeviceClass.TEMPERATURE,
+        device_class=NumberDeviceClass.TEMPERATURE,  # readwrite needs NumberDeviceClass / read is SensorDeviceClass
         unit=UnitOfTemperature.CELSIUS,
         entity_category=None,
         entity_icon="mdi:thermometer",


### PR DESCRIPTION
Should fix https://github.com/albaintor/homeassistant_electrolux_status/issues/83

Catalog updates just because they align with the changes in `api.py`. Only `api.py` is the cause of the issue

![image](https://github.com/user-attachments/assets/bfd1c37e-585e-40cb-9200-eb4ac27eb6fc)
