### PR TITLE
Appliance Capabilities via local JSON file - WELLBEING

### DIFF
--- a/custom_components/electrolux_status/__init__.py
+++ b/custom_components/electrolux_status/__init__.py
@@ -27,7 +27,6 @@ from .util import get_electrolux_session
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
-
 # noinspection PyUnusedLocal
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up this integration using YAML is not supported."""

--- a/custom_components/electrolux_status/api.py
+++ b/custom_components/electrolux_status/api.py
@@ -158,8 +158,6 @@ class ElectroluxLibraryEntity:
 
         May contain slashes for nested keys.
         """
-
-        # Some capabilities are not stored in hierarchy but directly in a key with format "a/b" like useSelections
         if self.capabilities.get(attr_name, None):
             return self.capabilities.get(attr_name)
 

--- a/custom_components/electrolux_status/appliance_definitions/PUREA9.json
+++ b/custom_components/electrolux_status/appliance_definitions/PUREA9.json
@@ -1,0 +1,145 @@
+{
+  "DoorOpen": {
+    "access": "read",
+    "type": "boolean"
+  },
+  "FilterType": {
+    "access": "read",
+    "type": "number"
+  },
+  "FilterLife": {
+    "access": "read",
+    "max": 100,
+    "min": 0,
+    "step": 1,
+    "type": "number"
+  },
+  "ECO2": {
+    "access": "read",
+    "max": 65535,
+    "min": 0,
+    "step": 1,
+    "type": "number"
+  },
+  "Humidity": {
+    "access": "read",
+    "step": 1,
+    "type": "number"
+  },
+  "Temp": {
+    "access": "read",
+    "step": 1,
+    "type": "number"
+  },
+  "PM1": {
+    "access": "read",
+    "max": 65535,
+    "min": 0,
+    "step": 1,
+    "type": "number"
+  },
+  "PM10": {
+    "access": "read",
+    "max": 65535,
+    "min": 0,
+    "step": 1,
+    "type": "number"
+  },
+  "PM2_5": {
+    "access": "read",
+    "max": 65535,
+    "min": 0,
+    "step": 1,
+    "type": "number"
+  },
+  "TVOC": {
+    "access": "read",
+    "max": 4295,
+    "min": 0,
+    "step": 1,
+    "type": "number"
+  },
+  "Fanspeed": {
+    "access": "readwrite",
+    "max": 9,
+    "min": 1,
+    "schedulable": true,
+    "step": 1,
+    "type": "int"
+  },
+  "Workmode": {
+    "access": "readwrite",
+    "schedulable": true,
+    "triggers": [
+      {
+        "action": {
+          "Fanspeed": {
+            "access": "readwrite",
+            "disabled": true,
+            "max": 9,
+            "min": 1,
+            "step": 1,
+            "type": "int"
+          }
+        },
+        "condition": {
+          "operand_1": "value",
+          "operand_2": "Auto",
+          "operator": "eq"
+        }
+      },
+      {
+        "action": {
+          "Fanspeed": {
+            "access": "readwrite",
+            "max": 9,
+            "min": 1,
+            "step": 1,
+            "type": "int"
+          }
+        },
+        "condition": {
+          "operand_1": "value",
+          "operand_2": "Manual",
+          "operator": "eq"
+        }
+      },
+      {
+        "action": {
+          "Fanspeed": {
+            "access": "readwrite",
+            "disabled": true,
+            "type": "int"
+          }
+        },
+        "condition": {
+          "operand_1": "value",
+          "operand_2": "PowerOff",
+          "operator": "eq"
+        }
+      }
+    ],
+    "type": "string",
+    "values": {
+      "Manual": {},
+      "PowerOff": {},
+      "Auto": {}
+    }
+  },
+  "UILight": {
+    "access": "readwrite",
+    "default": true,
+    "schedulable": true,
+    "type": "boolean"
+  },
+  "SafetyLock": {
+    "access": "readwrite",
+    "default": false,
+    "type": "boolean"
+  },
+  "Ionizer": {
+    "access": "readwrite",
+    "schedulable": true,
+    "type": "boolean"
+  }
+}

--- a/custom_components/electrolux_status/catalog_core.py
+++ b/custom_components/electrolux_status/catalog_core.py
@@ -15,12 +15,14 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import EntityCategory
 
 from .catalog_refridgerator import EHE6899SA
+from .catalog_purifier import A9
 from .model import ElectroluxDevice
 
 # definitions of model explicit overrides. These will be used to
 # create a new catalog with a merged definition of properties
 CATALOG_MODEL: dict[str, dict[str, ElectroluxDevice]] = {
     "EHE6899SA": EHE6899SA,
+    "A9": A9,
 }
 
 CATALOG_BASE: dict[str, ElectroluxDevice] = {

--- a/custom_components/electrolux_status/catalog_purifier.py
+++ b/custom_components/electrolux_status/catalog_purifier.py
@@ -1,0 +1,99 @@
+"""Defined catalog of entities for purifier type devices."""
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass
+
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfPower,
+    UnitOfTemperature,
+    UnitOfTime,
+    UnitOfVolume,
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    CONCENTRATION_PARTS_PER_MILLION,
+    CONCENTRATION_PARTS_PER_BILLION,
+)
+
+from homeassistant.helpers.entity import EntityCategory
+
+from .model import ElectroluxDevice
+
+A9 = {
+    "Temp": ElectroluxDevice(
+        device_class=SensorDeviceClass.TEMPERATURE,
+        unit=UnitOfTemperature.CELSIUS,
+        entity_category=None,
+        friendly_name="Temperature"
+    ),
+    "Humidity": ElectroluxDevice(
+        device_class=SensorDeviceClass.HUMIDITY,
+        unit=PERCENTAGE,
+        entity_category=None,
+        friendly_name="Humidity",
+    ),
+    "PM1": ElectroluxDevice(
+        device_class=SensorDeviceClass.PM1,
+        unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        entity_category=None,
+        friendly_name="PM1",
+    ),
+    "PM2_5": ElectroluxDevice(
+        device_class=SensorDeviceClass.PM25,
+        unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        entity_category=None,
+        friendly_name="PM2.5",
+    ),
+    "PM10": ElectroluxDevice(
+        device_class=SensorDeviceClass.PM10,
+        unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        entity_category=None,
+        friendly_name="PM10",
+    ),
+    "TVOC": ElectroluxDevice(
+        device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS,
+        unit=CONCENTRATION_PARTS_PER_BILLION,
+        entity_category=None,
+        friendly_name="TVOC",
+    ),
+    "ECO2": ElectroluxDevice(
+        device_class=SensorDeviceClass.CO2,
+        unit=CONCENTRATION_PARTS_PER_MILLION,
+        entity_category=None,
+        friendly_name="eCO2",
+    ),
+    "DoorOpen": ElectroluxDevice(
+        device_class=BinarySensorDeviceClass.DOOR,
+        unit=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        #entity_icon="mdi:cup-outline",
+        friendly_name="Door Open",
+    ),
+    "FilterType": ElectroluxDevice(
+        device_class=SensorDeviceClass.ENUM,
+        unit=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:air-filter",
+        value_mapping={
+            48: "BREEZE Complete air filter",
+            49: "CLEAN Ultrafine particle filter",
+            51: "CARE Ultimate protect filter",
+            64: "Breeze 360 filter",
+            65: "Clean 360 Ultrafine particle filter",
+            66: "Protect 360 filter",
+            67: "Breathe 360 filter",
+            68: "Fresh 360 filter",
+            96: "Breeze 360 filter",
+            99: "Breeze 360 filter",
+            100: "Fresh 360 filter",
+            192: "FRESH Odour protect filter",
+            0: "Filter",
+        },
+    ),
+    "FilterLife": ElectroluxDevice(
+        device_class=None,
+        unit=PERCENTAGE,
+        entity_category=None,
+        entity_icon="mdi:air-filter",
+        friendly_name="Filter Life",
+    ),
+}

--- a/custom_components/electrolux_status/const.py
+++ b/custom_components/electrolux_status/const.py
@@ -8,6 +8,9 @@ from homeassistant.const import Platform
 NAME = "Electrolux status"
 DOMAIN = "electrolux_status"
 DOMAIN_DATA = f"{DOMAIN}_data"
+COMPONENTS_DIRECTORY = "custom_components"
+LOOKUP_DIRECTORY = "appliance_definitions"
+LOOKUP_DIRECTORY_PATH = f"{COMPONENTS_DIRECTORY}/{DOMAIN}/{LOOKUP_DIRECTORY}/"
 
 # Platforms
 BINARY_SENSOR = Platform.BINARY_SENSOR

--- a/custom_components/electrolux_status/diagnostics.py
+++ b/custom_components/electrolux_status/diagnostics.py
@@ -64,10 +64,23 @@ async def _async_get_diagnostics(
     }
     for appliance in appliances_list:
         appliance_id = appliance["applianceId"]
-        data["appliances_detail"][appliance_id] = {
-            "capabilities": await app_entry.api.get_appliance_capabilities(appliance_id),
-            "state": await app_entry.api.get_appliance_state(appliance_id),
-        }
+        model_name = appliance.get("applianceData").get(
+            "modelName"
+        )
+        if model_name == "PUREA9":
+            appliance_definition_json_path = hass.config.path(LOOKUP_DIRECTORY_PATH + model_name + ".json")
+            async with aiofiles.open(appliance_definition_json_path, mode='r') as handle:
+                appliance_definition_json = await handle.read()
+            appliance_capabilities = json.loads(appliance_definition_json)
+            data["appliances_detail"][appliance_id] = {
+                "capabilities": appliance_capabilities,
+                "state": await app_entry.api.get_appliance_state(appliance_id),
+            }
+        else:
+            data["appliances_detail"][appliance_id] = {
+                "capabilities": await app_entry.api.get_appliance_capabilities(appliance_id),
+                "state": await app_entry.api.get_appliance_state(appliance_id),
+            }
     return async_redact_data(data, REDACT_CONFIG)
 
 

--- a/custom_components/electrolux_status/manifest.json
+++ b/custom_components/electrolux_status/manifest.json
@@ -9,7 +9,10 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/albaintor/homeassistant_electrolux_status/issues",
   "loggers": ["pyelectroluxocp"],
-  "requirements": ["pyelectroluxocp==0.0.19"],
+  "requirements": [
+    "pyelectroluxocp==0.0.19",
+    "aiofiles==24.1.0"
+  ],
   "ssdp": [],
   "version": "2.0.9",
   "zeroconf": []

--- a/custom_components/electrolux_status/number.py
+++ b/custom_components/electrolux_status/number.py
@@ -92,6 +92,8 @@ class ElectroluxNumber(ElectroluxEntity, NumberEntity):
         """Update the current value."""
         if self.unit == UnitOfTime.SECONDS:
             value = time_minutes_to_seconds(value)
+        if self.capability.get("step", 1) == 1:
+            value = int(value)
         client: OneAppApi = self.api
         if self.entity_source:
             command = {self.entity_source: {self.entity_attr: value}}


### PR DESCRIPTION
I tried a Wellbeing Appliances (Electrolux Purifier PUREA9) and I noticed that using the integration API, it reports no capabilities for the Purifier (while using the [https://api.developer.electrolux.one/api/v1/appliances/{applianceId}/info](https://api.developer.electrolux.one/api/v1/appliances/%7BapplianceId%7D/info) I can get the Purifier capabilities).
Of course the washing machine and the dryer work as expected.
Despite not reporting the capabilities, the integration API reports the Purifier state via websocket.
So I added the capabilities to put a local JSON file under `appliance_capabilities` folder that can be manually extracted from the [Electrolux Web API](https://developer.electrolux.one/documentation/reference#getUserAppliances). It can be extended for any other model.
In addiction I modified the `number` entity to check the configured `step`: if it is `1`, we can assume that the number is `int` so it will send the command as `int` instead of native `float`. This is because the Purifier accepts a fan speed between `1` to `9` and, sending a `float` (e.g. `3.0`) generates and error as it expects `3`. I think this is valid in general.