### PR TITLE
add SteamBake 7000 to supported devices list

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,4 @@ This list is non-exhaustive and your appliance may work even if not present here
 | ELECTROLUX | EOD6P77WZ | SteamBake 600 |
 | ELECTROLUX | KODDP77WX | SteamBake 600 |
 | AEG | BPE558370M | SteamBake 6000 |
+| AEG | BBS6402B | SteamBake 7000 |


### PR DESCRIPTION
Just added the AEG SteamBake 7000 device to my Home Assistant and it detects 21 sensors and functions.

So add it to the Readme's supported devices list.