### PR TITLE
Add workaround to make selections and switches work for user selection properties

### DIFF
--- a/custom_components/electrolux_status/api.py
+++ b/custom_components/electrolux_status/api.py
@@ -40,6 +40,17 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 HEADERS = {"Content-type": "application/json; charset=UTF-8"}
 
+def deep_merge_dicts(dict1, dict2):
+    """
+    Recursively merge two dictionaries.
+    """
+    result = dict1.copy()
+    for key, value in dict2.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge_dicts(result[key], value)
+        else:
+            result[key] = value
+    return result
 
 class ElectroluxLibraryEntity:
     """Electrolux Library Entity."""
@@ -651,7 +662,7 @@ class Appliance:
         """Update the reported data."""
         _LOGGER.debug("Electrolux update reported data %s", reported_data)
         try:
-            self.reported_state.update(reported_data)
+            self.reported_state.update(deep_merge_dicts(self.reported_state, reported_data))
             _LOGGER.debug("Electrolux updated reported data %s", self.state)
             self.update_missing_entities()
             for entity in self.entities:

--- a/custom_components/electrolux_status/button.py
+++ b/custom_components/electrolux_status/button.py
@@ -116,7 +116,15 @@ class ElectroluxButton(ElectroluxEntity, ButtonEntity):
         client: OneAppApi = self.api
         value = self.val_to_send
         if self.entity_source:
-            command = {self.entity_source: {self.entity_attr: value}}
+            if self.entity_source == "userSelections":
+                command = {
+                    self.entity_source: {
+                        "programUID": self.appliance_status["properties"]['reported']["userSelections"]['programUID'],
+                        self.entity_attr: value
+                    },
+                }
+            else:
+                command = {self.entity_source: {self.entity_attr: value}}
         else:
             command = {self.entity_attr: value}
         _LOGGER.debug("Electrolux send command %s", command)

--- a/custom_components/electrolux_status/number.py
+++ b/custom_components/electrolux_status/number.py
@@ -94,7 +94,15 @@ class ElectroluxNumber(ElectroluxEntity, NumberEntity):
             value = time_minutes_to_seconds(value)
         client: OneAppApi = self.api
         if self.entity_source:
-            command = {self.entity_source: {self.entity_attr: value}}
+            if self.entity_source == "userSelections":
+                command = {
+                    self.entity_source: {
+                        "programUID": self.appliance_status["properties"]['reported']["userSelections"]['programUID'],
+                        self.entity_attr: value
+                    },
+                }
+            else:
+                command = {self.entity_source: {self.entity_attr: value}}
         else:
             command = {self.entity_attr: value}
         _LOGGER.debug("Electrolux set value %s", command)

--- a/custom_components/electrolux_status/select.py
+++ b/custom_components/electrolux_status/select.py
@@ -161,10 +161,20 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
         if value is None:
             return
 
+        _LOGGER.debug("Electrolux select option before reported status %s", self.appliance_status["properties"]['reported'])
+
         client: OneAppApi = self.api
         command: dict[str, Any] = {}
         if self.entity_source:
-            command = {self.entity_source: {self.entity_attr: value}}
+            if self.entity_source == "userSelections":
+                command = {
+                    self.entity_source: {
+                        "programUID": self.appliance_status["properties"]['reported']["userSelections"]['programUID'],
+                        self.entity_attr: value
+                    },
+                }
+            else:
+                command = {self.entity_source: {self.entity_attr: value}}
         else:
             command = {self.entity_attr: value}
 

--- a/custom_components/electrolux_status/switch.py
+++ b/custom_components/electrolux_status/switch.py
@@ -71,7 +71,15 @@ class ElectroluxSwitch(ElectroluxEntity, SwitchEntity):
             value = "ON" if value else "OFF"
 
         if self.entity_source:
-            command = {self.entity_source: {self.entity_attr: value}}
+            if self.entity_source == "userSelections":
+                command = {
+                    self.entity_source: {
+                        "programUID": self.appliance_status["properties"]['reported']["userSelections"]['programUID'],
+                        self.entity_attr: value
+                    },
+                }
+            else:
+                command = {self.entity_source: {self.entity_attr: value}}
         else:
             command = {self.entity_attr: value}
         _LOGGER.debug("Electrolux set value %s", value)


### PR DESCRIPTION
Electrolux doesn't allow changing "userselections" without providing programuuid for some reason, added dirty workaround to pull through required data. 
Also handle partial updates from web socket.

I don't have time to write clean solution now.
Just some proof of concept that it works

#129 