### PR TITLE
fix: Update api lib version, add config input of country code

### DIFF
--- a/custom_components/electrolux_status/__init__.py
+++ b/custom_components/electrolux_status/__init__.py
@@ -7,6 +7,7 @@ from homeassistant.const import (
     CONF_LANGUAGE,
     CONF_PASSWORD,
     CONF_USERNAME,
+    CONF_COUNTRY_CODE,
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.core import HomeAssistant
@@ -17,6 +18,7 @@ from homeassistant.helpers.typing import ConfigType
 from .const import (
     CONF_RENEW_INTERVAL,
     DEFAULT_LANGUAGE,
+    DEFAULT_COUNTRY_CODE,
     DEFAULT_WEBSOCKET_RENEWAL_DELAY,
     DOMAIN,
     PLATFORMS,
@@ -44,10 +46,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     username = entry.data.get(CONF_USERNAME)
     password = entry.data.get(CONF_PASSWORD)
+    country_code = entry.data.get(CONF_COUNTRY_CODE, DEFAULT_COUNTRY_CODE)
     language = languages.get(entry.data.get(CONF_LANGUAGE, DEFAULT_LANGUAGE), "eng")
     session = async_get_clientsession(hass)
 
-    client = get_electrolux_session(username, password, session, language)
+    client = get_electrolux_session(username, password, country_code, session, language)
     coordinator = ElectroluxCoordinator(
         hass,
         client=client,

--- a/custom_components/electrolux_status/const.py
+++ b/custom_components/electrolux_status/const.py
@@ -30,6 +30,7 @@ CONF_NOTIFICATION_WARNING = "notifications_warning"
 
 # Defaults
 DEFAULT_LANGUAGE = "English"
+DEFAULT_COUNTRY_CODE = "us"
 DEFAULT_WEBSOCKET_RENEWAL_DELAY = 43200  # 12 hours
 
 # these are attributes that appear in the state file but not in the capabilities.

--- a/custom_components/electrolux_status/manifest.json
+++ b/custom_components/electrolux_status/manifest.json
@@ -10,7 +10,7 @@
   "issue_tracker": "https://github.com/albaintor/homeassistant_electrolux_status/issues",
   "loggers": ["pyelectroluxocp"],
   "requirements": [
-    "pyelectroluxocp==0.0.19",
+    "pyelectroluxocp==0.1.3",
     "aiofiles==24.1.0"
   ],
   "ssdp": [],

--- a/custom_components/electrolux_status/util.py
+++ b/custom_components/electrolux_status/util.py
@@ -22,10 +22,10 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
 def get_electrolux_session(
-    username, password, client_session, language="eng"
+    username, password, country_code, client_session, language="eng"
 ) -> OneAppApi:
     """Return OneAppApi Session."""
-    return OneAppApi(username, password, client_session)
+    return OneAppApi(username, password, country_code, client_session)
 
 
 def should_send_notification(config_entry, alert_severity, alert_status):


### PR DESCRIPTION
Electrolux now requires country code to fetch login providers list, updated integration to support that.

During setup users will now have to enter country code.
Added some default so older integration setups will still work. 

fixes #139 #140 #141