### PR TITLE
fix: Correct entity names

### DIFF
--- a/custom_components/electrolux_status/api.py
+++ b/custom_components/electrolux_status/api.py
@@ -127,7 +127,7 @@ class ElectroluxLibraryEntity:
                 words.append(group)
             else:
                 words.append(group.lower())
-        return " ".join(words).lower()
+        return " ".join(words).lower().capitalize()
 
     # def get_sensor_name_old(self, attr_name: str, container: str | None = None):
     #     """Convert sensor format.
@@ -463,7 +463,7 @@ class Appliance:
         entity_category = None
         entity_icon = None
         unit = self.data.get_entity_unit(capability)
-        display_name = f"{self.data.get_name()} {self.data.get_sensor_name(capability)}"
+        display_name = self.data.get_sensor_name(capability)
 
         # get the item definition from the catalog
         catalog_item = self.catalog.get(capability, None)


### PR DESCRIPTION
I believe this will fix #79 by following the [Home Assistant naming guidelines](https://developers.home-assistant.io/docs/core/entity/#entity-naming) more closely, primarily:

- Code already sets `has_entity_name` to `True`
- So, it should not have the device name in the entity name
- And the entity name is capitalised per https://developers.home-assistant.io/blog/2022/07/10/entity_naming/

**Note:** I have successfully tried out these edits directly on my HA setup, but do not have any dedicated testing environments