### PR TITLE
fix: Correct device uniqueness

### DIFF
--- a/custom_components/electrolux_status/entity.py
+++ b/custom_components/electrolux_status/entity.py
@@ -180,7 +180,7 @@ class ElectroluxEntity(CoordinatorEntity):
     def device_info(self):
         """Return identifiers of the device."""
         return {
-            "identifiers": {(DOMAIN, self.get_appliance.name)},
+            "identifiers": {(DOMAIN, self.pnc_id)},
             "name": self.get_appliance.name,
             "model": self.get_appliance.model,
             "manufacturer": self.get_appliance.brand,


### PR DESCRIPTION
This fixes a problem when multiple devices have the same name in the AEG app (which unfortunately is quite easy at the moment because the AEG app is completely broken when trying to rename a device if you have more than one of the same kind, e.g. 2 or more portable air conditioners)

Currently, if you have two devices in AEG app called "Air conditioner" this integration creates all the correct entities and they work fine, but they all end up grouped into a single device in Home Assistant, because this device `identifiers` is not unique

**Note:** I have successfully tried out these edits directly on my HA setup, but do not have any dedicated testing environments so I am not sure if changing this for existing users is safe!