### PR TITLE
Fix: Prevent duplicate entity creation for attributes in both static list and API capabilities

### DIFF
--- a/custom_components/electrolux_status/api.py
+++ b/custom_components/electrolux_status/api.py
@@ -131,7 +131,6 @@ class ElectroluxLibraryEntity:
 
     # def get_sensor_name_old(self, attr_name: str, container: str | None = None):
     #     """Convert sensor format.
-
     #     ex: "fCMiscellaneousState/detergentExtradosage" to "Detergent extradosage".
     #     """
     #     attr_name = attr_name.rpartition("/")[-1] or attr_name
@@ -609,6 +608,8 @@ class Appliance:
         self.data: ElectroluxLibraryEntity = data
         self.entities: list[ElectroluxEntity] = []
         entities: list[ElectroluxEntity] = []
+        processed_attributes: set[str] = set()
+
         # Extraction of the appliance capabilities & mapping to the known entities of the component
         # [ "applianceState", "autoDosing",..., "userSelections/analogTemperature",...]
         capabilities_names = self.data.sources_list()
@@ -642,10 +643,13 @@ class Appliance:
                 capabilities[keys[-1]] = catalog_item.capability_info
                 _LOGGER.debug("Electrolux adding static_attribute %s", static_attribute)
                 entities.extend(entity)
+                processed_attributes.add(static_attribute)
 
         # For each capability src
         if capabilities_names:
             for capability in capabilities_names:
+                if capability in processed_attributes:
+                    continue
                 if entity := self.get_entity(capability):
                     entities.extend(entity)
                 else:


### PR DESCRIPTION
Hi! This PR fixes a startup error that causes the integration to fail for some appliances, specifically those that report `applianceMode` (and potentially other static attributes) in their main capabilities payload.

The Problem:

The integration was logging a `Platform electrolux_status does not generate unique IDs` error during startup.

This happened because some attributes, like `applianceMode`, are defined in the `STATIC_ATTRIBUTES` list in `const.py`. The setup logic is designed to process this static list first and then process the full list of capabilities returned by the API.

However, for some appliances (especially newer models in the LATAM region), the `applianceMode` attribute is also present in the main capabilities list. This caused the `setup` function in `api.py` to process the same attribute twice, leading to an attempt to create two sensors with the exact same unique ID, which Home Assistant correctly blocks.

The Solution:

The fix is implemented in the `setup` method of the `Appliance` class (`api.py`).

1. A new `set()` called `processed_attributes` is introduced to keep track of the attributes that have already been turned into entities.

2. When an entity is created from the `STATIC_ATTRIBUTES` list, its name is added to this set.
 
3. Before creating an entity from the main capabilities list, the code now checks if the attribute name is already in the `processed_attributes` set.
 
4. If it is, the code skips it, effectively preventing the duplicate entity from being created. 

This ensures that each attribute is processed only once, resolving the conflict and allowing the integration to start correctly for all users, regardless of how their appliance reports its capabilities.

Thank you for considering this contribution!