### PR TITLE
fix(coordinator): retry on transient connection errors during setup

### DIFF
--- a/custom_components/electrolux_status/coordinator.py
+++ b/custom_components/electrolux_status/coordinator.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any
 
 import aiofiles
-from aiohttp import ClientResponseError
+from aiohttp import ClientConnectorError, ClientResponseError
 from pyelectroluxocp import OneAppApi
 from pyelectroluxocp.apiModels import UserTokenResponse
 from pyelectroluxocp.oneAppApiClient import UserToken
@@ -166,7 +166,16 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
             )
             # Load the token into the API
             self.api._user_token = self._token  # noqa: SLF001
-            await self.api._get_gigya_client()  # noqa: SLF001
+            try:
+                await self.api._get_gigya_client()  # noqa: SLF001
+            except ClientConnectorError as ex:
+                # Network/DNS not ready yet (typical at HA host boot before
+                # the resolver is up). Let HA retry the entry setup instead
+                # of failing permanently.
+                _LOGGER.debug(
+                    "Network not ready while validating stored token: %s", ex
+                )
+                raise ConfigEntryNotReady from ex
 
     async def async_login(self) -> bool:
         """Authenticate with the service."""
@@ -190,6 +199,15 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
                     "Please log out of another device or wait until an existing session expires"
                 ) from ex
             raise ConfigEntryError from ex
+        except ClientConnectorError as ex:
+            # Treat connection-level failures (DNS, no route, refused) as
+            # transient so HA retries the entry setup with backoff. This is
+            # the typical failure mode when the integration starts before
+            # the host's network/DNS is fully up after a reboot.
+            _LOGGER.debug(
+                "Network not ready while logging in to ElectroluxStatus: %s", ex
+            )
+            raise ConfigEntryNotReady from ex
         except Exception as ex:
             _LOGGER.error("Could not log in to ElectroluxStatus, %s", ex)
             raise ConfigEntryError from ex


### PR DESCRIPTION
## Summary

This PR makes the integration recover automatically from transient connection-level failures during `async_setup_entry`, rather than ending up in `setup_error` until a manual reload.

Fixes #198.

## The bug, in short

On HA host cold boot, `async_setup_entry` runs before the host's DNS / network is fully up. The first `aiohttp` request inside `coordinator.get_stored_token()` raises `ClientConnectorDNSError`, which is not caught and becomes a setup error. Home Assistant does not retry — the user has to manually reload the entry, after which everything works. Full trace, environment and reproduction steps in the linked issue.

## Changes

`custom_components/electrolux_status/coordinator.py`:

1. Import `ClientConnectorError` from `aiohttp`.
2. `get_stored_token()`: wrap the `self.api._get_gigya_client()` call so a `ClientConnectorError` raises `ConfigEntryNotReady` instead of bubbling up unhandled.
3. `async_login()`: add an explicit `except ClientConnectorError` ahead of the generic `except Exception`, raising `ConfigEntryNotReady` so HA retries with backoff.

The existing `ClientResponseError` mapping (HTTP 4xx / 5xx, including the 429 → `ConfigEntryNotReady` special case) and the broad `except Exception` fallback are intentionally untouched — those still raise `ConfigEntryError` for genuinely permanent failures.

## Why `ConfigEntryNotReady`

`ClientConnectorError` and its subclasses (`ClientConnectorDNSError`, `ClientConnectorCertificateError`, …) are raised before any HTTP exchange happens. They reliably indicate either "we can't reach the API" (DNS, routing, firewall) or "the host's network stack isn't ready yet" — both transient. `ConfigEntryNotReady` is HA's documented contract for that situation and triggers exponential-backoff retry; `ConfigEntryError` is a terminal state and skips retries.

This is the same pattern used by core cloud integrations (Tuya, Google services, etc.) for the same boot-timing problem.

## Test plan

- [x] Manually reproduced the original failure mode by power-cycling the HA host. Without the patch, the entry stays in `setup_error` until a manual reload. With the patch, the entry transitions through `setup_retry` → `loaded` automatically once DNS is up.
- [x] Login with valid credentials when network is already up — unchanged behaviour.
- [x] Login with bad credentials — still raises `ConfigEntryAuthFailed` via the existing path.
- [x] HTTP 429 from upstream — still raises `ConfigEntryNotReady` via the existing `ClientResponseError` branch.
