### PR TITLE
fix: sanitize entity IDs, fix device identifier unpack, fix options flow config_entry setter

### DIFF
--- a/custom_components/electrolux_status/__init__.py
+++ b/custom_components/electrolux_status/__init__.py
@@ -124,16 +124,20 @@ def _async_remove_old_device_identifiers(
         device_list = list(device_registry.devices.values())  # <-- make a list copy
         for device in device_list:
             # Only check devices for this domain
-            try:
-                for domain, deviceid in device.identifiers:
-                    if domain != DOMAIN:
-                        continue
+            for identifier in device.identifiers:
+                # Identifiers from other integrations (homekit, rfxtrx, etc.)
+                # may have more than 2 elements — only unpack what we need.
+                if len(identifier) < 2:
+                    continue
+                domain = identifier[0]
+                deviceid = identifier[1]
 
-                    if deviceid not in all_api_ids:
-                        _LOGGER.debug("Removing old device idendifier: %s", deviceid)
-                        device_registry.async_remove_device(device.id)
-            except Exception as e:
-                _LOGGER.error("Unable to remove old device idendifier, please report: %s %s", device.identifiers, e)
+                if domain != DOMAIN:
+                    continue
+
+                if deviceid not in all_api_ids:
+                    _LOGGER.debug("Removing old device identifier: %s", deviceid)
+                    device_registry.async_remove_device(device.id)
 
 
 async def async_remove_config_entry_device(

--- a/custom_components/electrolux_status/config_flow.py
+++ b/custom_components/electrolux_status/config_flow.py
@@ -159,9 +159,12 @@ class ElectroluxStatusFlowHandler(ConfigFlow, domain=DOMAIN):
 class ElectroluxStatusOptionsFlowHandler(OptionsFlow):
     """Config flow options handler for Electrolux Status."""
 
-    def __init__(self, config_entry) -> None:
+    def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize HACS options flow."""
-        self.config_entry = config_entry
+        # In HA 2026.x+, OptionsFlow.config_entry is a read-only property managed
+        # by the base class — assigning to it raises AttributeError. Store our own
+        # reference privately for data access throughout this flow.
+        self._config_entry = config_entry
         self.options = dict(config_entry.options)
 
     async def async_step_init(self, user_input=None) -> ConfigFlowResult:
@@ -174,12 +177,12 @@ class ElectroluxStatusOptionsFlowHandler(OptionsFlow):
             self.options.update(user_input)
             return await self._update_options()
 
-        selected_language = self.config_entry.data.get(CONF_LANGUAGE, DEFAULT_LANGUAGE)
-        current_password = self.config_entry.data.get(CONF_PASSWORD, None)
-        current_country_code = self.config_entry.data.get(CONF_COUNTRY_CODE, None)
-        notify_alert = self.config_entry.data.get(CONF_NOTIFICATION_DEFAULT, True)
-        notify_warning = self.config_entry.data.get(CONF_NOTIFICATION_WARNING, False)
-        notify_diagnostic = self.config_entry.data.get(CONF_NOTIFICATION_DIAG, False)
+        selected_language = self._config_entry.data.get(CONF_LANGUAGE, DEFAULT_LANGUAGE)
+        current_password = self._config_entry.data.get(CONF_PASSWORD, None)
+        current_country_code = self._config_entry.data.get(CONF_COUNTRY_CODE, None)
+        notify_alert = self._config_entry.data.get(CONF_NOTIFICATION_DEFAULT, True)
+        notify_warning = self._config_entry.data.get(CONF_NOTIFICATION_WARNING, False)
+        notify_diagnostic = self._config_entry.data.get(CONF_NOTIFICATION_DIAG, False)
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
@@ -228,7 +231,7 @@ class ElectroluxStatusOptionsFlowHandler(OptionsFlow):
         """Update config entry options."""
         _LOGGER.debug("Electrolux updating configuration")
         data = {
-            **self.config_entry.data,
+            **self._config_entry.data,
             CONF_PASSWORD: self.options[CONF_PASSWORD],
             CONF_COUNTRY_CODE: self.options[CONF_COUNTRY_CODE],
             CONF_LANGUAGE: self.options[CONF_LANGUAGE],
@@ -236,8 +239,8 @@ class ElectroluxStatusOptionsFlowHandler(OptionsFlow):
             CONF_NOTIFICATION_WARNING: self.options[CONF_NOTIFICATION_WARNING],
             CONF_NOTIFICATION_DIAG: self.options[CONF_NOTIFICATION_DIAG],
         }
-        self.hass.config_entries.async_update_entry(self.config_entry, data=data)
+        self.hass.config_entries.async_update_entry(self._config_entry, data=data)
         return self.async_create_entry(
-            title=self.config_entry.data.get(CONF_USERNAME),
+            title=self._config_entry.data.get(CONF_USERNAME),
             data=data,
         )

--- a/custom_components/electrolux_status/entity.py
+++ b/custom_components/electrolux_status/entity.py
@@ -1,6 +1,7 @@
 """Entity platform for Electrolux Status."""
 
 import logging
+import re
 from typing import Any, cast
 
 from pyelectroluxocp import OneAppApi
@@ -80,7 +81,18 @@ class ElectroluxEntity(CoordinatorEntity):
         self.pnc_id = pnc_id
         self.unit = unit
         self.capability = capability
-        self.entity_id = f"{self.entity_domain}.{self.get_appliance.brand}_{self.get_appliance.name}_{self.entity_source}_{self.entity_attr}"
+        _raw_entity_id = (
+            f"{self.entity_domain}."
+            f"{self.get_appliance.brand}_{self.get_appliance.name}_"
+            f"{self.entity_source}_{self.entity_attr}"
+        )
+        # HA entity IDs must be lowercase [a-z0-9_.] with no consecutive underscores.
+        # The appliance brand/name/attr values may contain uppercase, camelCase, spaces,
+        # and hyphens. entity_source can also be empty, causing double underscores.
+        _domain, _object = _raw_entity_id.split(".", 1)
+        _object = re.sub(r"[^a-z0-9_]", "_", _object.lower())  # lowercase + replace invalid chars
+        _object = re.sub(r"_+", "_", _object).strip("_")        # collapse consecutive underscores
+        self.entity_id = f"{_domain}.{_object}"
         if catalog_entry:
             self.entity_registry_enabled_default = catalog_entry.entity_registry_enabled_default
         _LOGGER.debug("Electrolux new entity %s for appliance %s", name, pnc_id)


### PR DESCRIPTION
## Summary

This PR fixes three distinct bugs reported across 8 issues, all triggered by Home Assistant 2026.x breaking-change enforcement. Every change is surgical and confined to the affected code path.

---

## Key Changes

### 1. `entity.py` — Sanitize generated entity IDs

**Fixes: #179, #187, #190, #204**

The entity ID was constructed by concatenating raw appliance data (brand, name, source, attribute) with no sanitisation. This produced IDs with:
- Uppercase letters (`AEG_Washer`, `ELECTROLUX_Lavastoviglie`)
- camelCase attribute names (`doorLock`, `linkQualityIndicator`)
- Double underscores when `entity_source` is empty (`sensor.AEG_Washer__timeToEnd`)
- Spaces when appliance names contain them (`binary_sensor.ELECTROLUX_Kitchen Fridge_...`)

HA 2026.2 now strictly validates entity IDs and will **stop working entirely in 2027.2.0**.

**Fix:** Two-step sanitisation pipeline:
```python
_object = re.sub(r"[^a-z0-9_]", "_", _object.lower())  # lowercase + replace all invalid chars
_object = re.sub(r"_+", "_", _object).strip("_")        # collapse consecutive underscores
```

> ⚠️ **Breaking change for existing users:** Entity IDs will be renamed on first restart (e.g. `sensor.AEG_Washer__timeToEnd` → `sensor.aeg_washer_timetoend`). Automations and dashboards referencing old entity IDs will need updating. However, the old IDs were already *invalid* and were going to stop working in 2027.2.0 regardless.

---

### 2. `__init__.py` — Fix device identifier tuple unpacking

**Fixes: #189 (Bug #1), #192, #193, #194**

`_async_remove_old_device_identifiers()` iterates the **global** device registry (all integrations) and assumed every identifier tuple was exactly 2 elements `(domain, id)`. Other integrations register tuples with 3 or 4 elements:
- `homekit`: `('homekit', '<uuid>', 'homekit.bridge')` — 3 elements
- `rfxtrx`: `('rfxtrx', '52', 'c', '00:01')` — 4 elements
- `adguard`: `('adguard', '192.168.0.3', 8083, '/control/')` — 4 elements
- `bosch`: `('bosch', 'dhw1', '101601004')` — 3 elements

The v2.3.1 attempt wrapped this in `try/except Exception` which masked the error but didn't fix it.

**Fix:** Replace destructured unpack with index-based access and a length guard:
```python
for identifier in device.identifiers:
    if len(identifier) < 2:
        continue
    domain = identifier[0]
    deviceid = identifier[1]
    if domain != DOMAIN:
        continue
    ...
```

Also fixes typo: `idendifier` → `identifier` in log message.

---

### 3. `config_flow.py` — Fix `OptionsFlow.config_entry` read-only property

**Fixes: #189 (Bug #2)**

Since HA 2026.x, `OptionsFlow.config_entry` is a **read-only property** managed by the base class. `ElectroluxStatusOptionsFlowHandler.__init__()` was assigning `self.config_entry = config_entry` which raises `AttributeError: property has no setter` whenever the integration's options dialog is opened in the UI.

**Fix:** Store the reference as `self._config_entry` and update all 8 usages throughout the class.

---

## Why This Is Needed

All three bugs are caused by HA 2026.x breaking changes that tightened entity ID validation, hardened the device registry API, and made `OptionsFlow` base class properties read-only. These are not regressions in this integration — they are upstream enforcement of long-standing best practices that the integration had not yet adopted. Without this fix, users on HA 2026.x see startup errors on every boot, the options dialog is broken, and the integration will stop working entirely when HA 2027.2.0 ships.

## Issues Closed

Closes #179
Closes #187
Closes #189
Closes #190
Closes #192
Closes #193
Closes #194
Closes #204
Closes #207