### PR TITLE
Stop leaking the bearer token into the log, and keep diagnostics working

### DIFF
--- a/custom_components/electrolux_status/coordinator.py
+++ b/custom_components/electrolux_status/coordinator.py
@@ -372,8 +372,15 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
                         json.dumps(appliance_capabilities),
                     )
                 except Exception as exception:  # noqa: BLE001
+                    # Pass the exception through a format placeholder. Without
+                    # one, logging cannot format the record and falls back to
+                    # dumping the raw argument - for a ClientResponseError that
+                    # includes the request headers, which carry the account's
+                    # bearer token. str() of the exception carries the status
+                    # and URL only.
                     _LOGGER.warning(
-                        "Electrolux unable to retrieve capabilities, we are going on our own",
+                        "Electrolux unable to retrieve capabilities for %s, we are going on our own: %s",
+                        appliance_id,
                         exception,
                     )
                     # raise ConfigEntryNotReady(

--- a/custom_components/electrolux_status/diagnostics.py
+++ b/custom_components/electrolux_status/diagnostics.py
@@ -79,10 +79,24 @@ async def _async_get_diagnostics(
             }
         else:
             data["appliances_detail"][appliance_id] = {
-                "capabilities": await app_entry.api.get_appliance_capabilities(appliance_id),
-                "state": await app_entry.api.get_appliance_state(appliance_id),
+                "capabilities": await _safe_call(app_entry.api.get_appliance_capabilities(appliance_id)),
+                "state": await _safe_call(app_entry.api.get_appliance_state(appliance_id)),
             }
     return async_redact_data(data, REDACT_CONFIG)
+
+
+async def _safe_call(coro: Any) -> Any:
+    """Await a coroutine, returning the error instead of raising.
+
+    Not every appliance exposes every endpoint - robot vacuums return 404 for
+    /capabilities, for instance. Letting that propagate made the whole
+    diagnostics download fail with a 500, which is exactly when a user most
+    needs it.
+    """
+    try:
+        return await coro
+    except Exception as err:  # noqa: BLE001
+        return {"error": f"{type(err).__name__}: {err}"}
 
 
 @callback


### PR DESCRIPTION
## Proposed change

Two independent bugs, both triggered by an account containing an appliance whose
`/capabilities` endpoint returns 404. A PUREi9 robot vacuum does this, so any
account with one is affected.

### 1. The account's bearer token is written to `home-assistant.log`

`coordinator.py` passes the exception to `_LOGGER.warning` with no format
placeholder:

```python
_LOGGER.warning(
    "Electrolux unable to retrieve capabilities, we are going on our own",
    exception,
)
```

Logging cannot format the record, so it falls back to dumping the raw argument —
and the repr of an `aiohttp` `ClientResponseError` includes `RequestInfo.headers`,
which carry `Authorization: Bearer …`. The result in the log is:

```
Bad logger message: Electrolux unable to retrieve capabilities, we are going on
our own ((ClientResponseError(RequestInfo(url=URL('…/capabilities'), method='GET',
headers=<CIMultiDictProxy('Host': …, 'Authorization': 'Bearer eyJraWQiOiI…
```

That matters because this is exactly the file users paste into bug reports. I hit
it three separate times on my own instance while working on something unrelated.

Formatting the exception through `%s` emits the status and URL only, which is the
useful part:

```
Electrolux unable to retrieve capabilities for <id>, we are going on our own:
404, message='Not Found', url='…/capabilities'
```

### 2. Diagnostics returns HTTP 500 for the whole account

`diagnostics.py` awaits `get_appliance_capabilities` for every appliance with no
error handling, so one 404 aborts the entire dump — precisely when a user is
trying to collect information for a bug report. Per-appliance errors are now
recorded in the dump instead of aborting it, so the other appliances' payloads
still come through.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

Found while capturing capability documents for hob support (a separate PR). Kept
deliberately separate and minimal so the token fix can be reviewed and released
without waiting on a feature branch. Two files, +24 −3.

Verified against a live account containing a PUREi9 that reproduces both.
