### PR TITLE
Add HB induction hob support (tested with AEG CCE84779CB)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  pytest:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "actions/setup-python@v5"
+        with:
+          # Home Assistant 2026.8 requires >=3.14.2
+          python-version: "3.14"
+      - name: Install dependencies
+        run: pip install -r requirements-test.txt
+      - name: Run tests
+        run: python -m pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ This list is non-exhaustive and your appliance may work even if not present here
 | ELECTROLUX   | EHE6899SA | 609L UltimateTaste 900 |
 | ELECTROLUX   | EHE6799SA | 609L UltimateTaste 900 |
 
+**Induction Hob**
+
+| Manufacturer | Model      | Description                                 |
+| :----------- | :--------- | :------------------------------------------ |
+| AEG          | CCE84779CB | 8000 ComboHob, with integrated extractor    |
+
+Hobs are supported by appliance type (`HB`), so other Wi-Fi hobs are likely to
+work even though only the model above has been verified on real hardware. Hob
+zones are discovered from the appliance itself, so bridged and flexible zones
+appear automatically.
+
+Cooking zone power, running time, residual heat and pot detection are exposed
+read-only. The integrated extractor is controllable: fan speed, manual/automatic
+mode, hob-to-hood level and run-on duration. Cooking controls are deliberately
+not writable, see `custom_components/electrolux_status/catalog_hob.py`.
+
 **Dishwasher**
 
 | Manufacturer | Model      | Description    |

--- a/custom_components/electrolux_status/api.py
+++ b/custom_components/electrolux_status/api.py
@@ -1,6 +1,5 @@
 """API for Electrolux Status."""
 
-import copy
 from dataclasses import replace
 import logging
 import re
@@ -63,31 +62,23 @@ CONTAINER_INDEX_RE = re.compile(r"^([A-Za-z]+?)(\d+)/")
 # Catalog keys using the wildcard above are patterns, never real capabilities.
 CATALOG_WILDCARD = "*"
 
-# A wildcard entry's friendly_name may carry this placeholder, replaced with
-# the container's index so each zone or module gets a distinguishable name.
-CATALOG_INDEX_PLACEHOLDER = "{index}"
 
+def catalog_wildcard_key(capability: str) -> tuple[str, str] | None:
+    """Return the wildcard form of a nested capability path and its index.
 
-def catalog_wildcard_key(capability: str) -> str | None:
-    """Return the wildcard form of a nested capability path, or None.
-
-    "hobZone12/runningTime" -> "hobZone*/runningTime"
+    "hobZone12/runningTime" -> ("hobZone*/runningTime", "12")
     "userSelections/analogTemperature" -> None (no numeric container suffix)
     """
     match = CONTAINER_INDEX_RE.match(capability)
     if not match:
         return None
-    attribute = capability.split("/", 1)[1]
-    return f"{match.group(1)}{CATALOG_WILDCARD}/{attribute}"
+    container, index = match.groups()
+    return f"{container}{CATALOG_WILDCARD}/{capability[match.end() :]}", index
 
 
-def catalog_container_index(capability: str) -> str | None:
-    """Return the index of a numbered capability container, or None.
-
-    "hobZone7/runningTime" -> "7"
-    """
-    match = CONTAINER_INDEX_RE.match(capability)
-    return match.group(2) if match else None
+def is_catalog_pattern(key: str) -> bool:
+    """Return whether a catalog key is a pattern rather than a capability."""
+    return CATALOG_WILDCARD in key
 
 
 class ElectroluxLibraryEntity:
@@ -407,38 +398,38 @@ class Appliance:
     def catalog(self) -> dict[str, ElectroluxDevice]:
         """Return the defined catalog for the appliance.
 
-        Layered from most generic to most specific: the base catalog, then any
-        overrides for the reported appliance type, then any overrides for the
-        exact model. Appliance-type overrides are preferred over model ones as
-        they apply to every model of that type.
+        Applied from most generic to most specific, so the base catalog is
+        overridden by the reported appliance type, which is in turn overridden
+        by the exact model. Prefer adding to the appliance-type catalog: it
+        covers every model of that type.
         """
         # Cached for the appliance's lifetime. The appliance type does not
         # change, and caching also means a later state push that happens to
         # omit applianceInfo cannot silently switch the catalog out from
         # under entities that were already built from it.
-        if self._catalog is not None:
-            return self._catalog
+        if self._catalog is None:
+            overrides = [
+                override
+                for override in (
+                    CATALOG_APPLIANCE_TYPE.get(self.appliance_type),
+                    CATALOG_MODEL.get(self.model),
+                )
+                if override
+            ]
+            if not overrides:
+                self._catalog = CATALOG_BASE
+            else:
+                _LOGGER.debug(
+                    "Extending catalog for appliance type %s / model %s",
+                    self.appliance_type,
+                    self.model,
+                )
+                # Shallow copy: overrides replace whole entries, they never
+                # mutate one, so the base entries can safely be shared.
+                self._catalog = dict(CATALOG_BASE)
+                for override in overrides:
+                    self._catalog.update(override)
 
-        overrides = [
-            CATALOG_APPLIANCE_TYPE.get(self.appliance_type),
-            CATALOG_MODEL.get(self.model),
-        ]
-        if not any(overrides):
-            self._catalog = CATALOG_BASE
-            return self._catalog
-
-        _LOGGER.debug(
-            "Extending catalog for appliance type %s / model %s",
-            self.appliance_type,
-            self.model,
-        )
-        # Make a deep copy of the base catalog to preserve it
-        new_catalog = copy.deepcopy(CATALOG_BASE)
-        for override in overrides:
-            if override:
-                new_catalog.update(override)
-
-        self._catalog = new_catalog
         return self._catalog
 
     def get_catalog_entry(self, capability: str) -> ElectroluxDevice | None:
@@ -451,15 +442,21 @@ class Appliance:
         catalog = self.catalog
         if entry := catalog.get(capability):
             return entry
-        wildcard = catalog_wildcard_key(capability)
-        if not wildcard or not (entry := catalog.get(wildcard)):
+        if not (wildcard := catalog_wildcard_key(capability)):
+            return None
+        key, index = wildcard
+        if not (entry := catalog.get(key)):
             return None
         # A wildcard entry describes every container of its kind, so its name
-        # has to carry the index or every zone ends up with the same name.
-        index = catalog_container_index(capability)
-        if index and entry.friendly_name and CATALOG_INDEX_PLACEHOLDER in entry.friendly_name:
-            return replace(entry, friendly_name=entry.friendly_name.format(index=index))
-        return entry
+        # has to carry the index or every zone ends up with the same name. If
+        # an entry forgets the placeholder, drop back to the generated name -
+        # that already contains the container, so names stay distinct.
+        if not entry.friendly_name:
+            return entry
+        if "{index}" not in entry.friendly_name:
+            _LOGGER.debug("Catalog pattern %s has no {index} in its name, using the generated one", key)
+            return replace(entry, friendly_name=None)
+        return replace(entry, friendly_name=entry.friendly_name.format(index=index))
 
     def update_missing_entities(self) -> None:
         """Add missing entities when no capabilities returned by the API.
@@ -470,7 +467,7 @@ class Appliance:
             return
 
         for key, catalog_item in self.catalog.items():
-            if CATALOG_WILDCARD in key:
+            if is_catalog_pattern(key):
                 # Pattern entry, not a capability an appliance can report.
                 continue
             category = self.data.get_category(key)
@@ -679,9 +676,8 @@ class Appliance:
             if self.get_state(static_attribute) is None:
                 continue
             if capabilities_names and static_attribute in capabilities_names:
-                # The appliance does advertise it after all, so let the
-                # capability document drive it rather than creating a second,
-                # duplicate entity with the same unique id.
+                # Both entities would share one unique id, and HA drops the
+                # second. Let the capability document drive it.
                 _LOGGER.debug(
                     "Electrolux static_attribute %s also advertised as a capability, skipping",
                     static_attribute,

--- a/custom_components/electrolux_status/api.py
+++ b/custom_components/electrolux_status/api.py
@@ -16,7 +16,7 @@ from homeassistant.const import Platform, UnitOfTemperature
 
 from .binary_sensor import ElectroluxBinarySensor
 from .button import ElectroluxButton
-from .catalog_core import CATALOG_BASE, CATALOG_MODEL
+from .catalog_core import CATALOG_APPLIANCE_TYPE, CATALOG_BASE, CATALOG_MODEL
 from .const import (
     ATTRIBUTES_BLACKLIST,
     ATTRIBUTES_WHITELIST,
@@ -51,6 +51,29 @@ def deep_merge_dicts(dict1, dict2):
         else:
             result[key] = value
     return result
+
+
+# Matches the numeric suffix of a capability container, e.g. the "1" of
+# "hobZone1/runningTime". Appliances that report a variable number of identical
+# containers (hob zones, heating modules) can then be described once in a
+# catalog as "hobZone*/runningTime" instead of per index.
+CONTAINER_INDEX_RE = re.compile(r"^([A-Za-z]+?)\d+/")
+
+# Catalog keys using the wildcard above are patterns, never real capabilities.
+CATALOG_WILDCARD = "*"
+
+
+def catalog_wildcard_key(capability: str) -> str | None:
+    """Return the wildcard form of a nested capability path, or None.
+
+    "hobZone12/runningTime" -> "hobZone*/runningTime"
+    "userSelections/analogTemperature" -> None (no numeric container suffix)
+    """
+    match = CONTAINER_INDEX_RE.match(capability)
+    if not match:
+        return None
+    attribute = capability.split("/", 1)[1]
+    return f"{match.group(1)}{CATALOG_WILDCARD}/{attribute}"
 
 
 class ElectroluxLibraryEntity:
@@ -342,6 +365,7 @@ class Appliance:
         """Initiate the appliance."""
         self.own_capabilties = False
         self.data = None
+        self._catalog: dict[str, ElectroluxDevice] | None = None
         self.coordinator = coordinator
         self.model = model
         self.pnc_id = pnc_id
@@ -367,22 +391,51 @@ class Appliance:
 
     @property
     def catalog(self) -> dict[str, ElectroluxDevice]:
-        """Return the defined catalog for the appliance."""
-        # TODO: Use appliance_type as opposed to model?
-        if self.model in CATALOG_MODEL:
-            _LOGGER.debug("Extending catalog for %s", self.model)
-            # Make a deep copy of the base catalog to preserve it
-            new_catalog = copy.deepcopy(CATALOG_BASE)
+        """Return the defined catalog for the appliance.
 
-            # Get the specific model's extended catalog
-            model_catalog = CATALOG_MODEL[self.model]
+        Layered from most generic to most specific: the base catalog, then any
+        overrides for the reported appliance type, then any overrides for the
+        exact model. Appliance-type overrides are preferred over model ones as
+        they apply to every model of that type.
+        """
+        if self._catalog is not None:
+            return self._catalog
 
-            # Update the existing catalog with the extended information for this model
-            for key, device in model_catalog.items():
-                new_catalog[key] = device
+        overrides = [
+            CATALOG_APPLIANCE_TYPE.get(self.appliance_type),
+            CATALOG_MODEL.get(self.model),
+        ]
+        if not any(overrides):
+            self._catalog = CATALOG_BASE
+            return self._catalog
 
-            return new_catalog
-        return CATALOG_BASE
+        _LOGGER.debug(
+            "Extending catalog for appliance type %s / model %s",
+            self.appliance_type,
+            self.model,
+        )
+        # Make a deep copy of the base catalog to preserve it
+        new_catalog = copy.deepcopy(CATALOG_BASE)
+        for override in overrides:
+            if override:
+                new_catalog.update(override)
+
+        self._catalog = new_catalog
+        return self._catalog
+
+    def get_catalog_entry(self, capability: str) -> ElectroluxDevice | None:
+        """Return the catalog entry describing a capability path.
+
+        Falls back to the wildcard form of the path so a catalog can describe
+        repeated containers without assuming how many of them an appliance
+        reports, or that they are numbered contiguously.
+        """
+        catalog = self.catalog
+        if entry := catalog.get(capability):
+            return entry
+        if wildcard := catalog_wildcard_key(capability):
+            return catalog.get(wildcard)
+        return None
 
     def update_missing_entities(self) -> None:
         """Add missing entities when no capabilities returned by the API.
@@ -393,6 +446,9 @@ class Appliance:
             return
 
         for key, catalog_item in self.catalog.items():
+            if CATALOG_WILDCARD in key:
+                # Pattern entry, not a capability an appliance can report.
+                continue
             category = self.data.get_category(key)
             if (
                 category
@@ -447,7 +503,7 @@ class Appliance:
         display_name = self.data.get_sensor_name(capability)
 
         # get the item definition from the catalog
-        catalog_item = self.catalog.get(capability, None)
+        catalog_item = self.get_catalog_entry(capability)
         if catalog_item:
             if capability_info is None:
                 capability_info = catalog_item.capability_info
@@ -598,7 +654,16 @@ class Appliance:
             # attr not found in state, next attr
             if self.get_state(static_attribute) is None:
                 continue
-            if catalog_item := self.catalog.get(static_attribute, None):
+            if capabilities_names and static_attribute in capabilities_names:
+                # The appliance does advertise it after all, so let the
+                # capability document drive it rather than creating a second,
+                # duplicate entity with the same unique id.
+                _LOGGER.debug(
+                    "Electrolux static_attribute %s also advertised as a capability, skipping",
+                    static_attribute,
+                )
+                continue
+            if catalog_item := self.get_catalog_entry(static_attribute):
                 if (entity := self.get_entity(static_attribute)) is None:
                     # catalog definition and automatic checks fail to determine type
                     _LOGGER.debug("Electrolux static_attribute undefined %s", static_attribute)

--- a/custom_components/electrolux_status/api.py
+++ b/custom_components/electrolux_status/api.py
@@ -1,6 +1,7 @@
 """API for Electrolux Status."""
 
 import copy
+from dataclasses import replace
 import logging
 import re
 from typing import Any
@@ -57,10 +58,14 @@ def deep_merge_dicts(dict1, dict2):
 # "hobZone1/runningTime". Appliances that report a variable number of identical
 # containers (hob zones, heating modules) can then be described once in a
 # catalog as "hobZone*/runningTime" instead of per index.
-CONTAINER_INDEX_RE = re.compile(r"^([A-Za-z]+?)\d+/")
+CONTAINER_INDEX_RE = re.compile(r"^([A-Za-z]+?)(\d+)/")
 
 # Catalog keys using the wildcard above are patterns, never real capabilities.
 CATALOG_WILDCARD = "*"
+
+# A wildcard entry's friendly_name may carry this placeholder, replaced with
+# the container's index so each zone or module gets a distinguishable name.
+CATALOG_INDEX_PLACEHOLDER = "{index}"
 
 
 def catalog_wildcard_key(capability: str) -> str | None:
@@ -74,6 +79,15 @@ def catalog_wildcard_key(capability: str) -> str | None:
         return None
     attribute = capability.split("/", 1)[1]
     return f"{match.group(1)}{CATALOG_WILDCARD}/{attribute}"
+
+
+def catalog_container_index(capability: str) -> str | None:
+    """Return the index of a numbered capability container, or None.
+
+    "hobZone7/runningTime" -> "7"
+    """
+    match = CONTAINER_INDEX_RE.match(capability)
+    return match.group(2) if match else None
 
 
 class ElectroluxLibraryEntity:
@@ -398,6 +412,10 @@ class Appliance:
         exact model. Appliance-type overrides are preferred over model ones as
         they apply to every model of that type.
         """
+        # Cached for the appliance's lifetime. The appliance type does not
+        # change, and caching also means a later state push that happens to
+        # omit applianceInfo cannot silently switch the catalog out from
+        # under entities that were already built from it.
         if self._catalog is not None:
             return self._catalog
 
@@ -433,9 +451,15 @@ class Appliance:
         catalog = self.catalog
         if entry := catalog.get(capability):
             return entry
-        if wildcard := catalog_wildcard_key(capability):
-            return catalog.get(wildcard)
-        return None
+        wildcard = catalog_wildcard_key(capability)
+        if not wildcard or not (entry := catalog.get(wildcard)):
+            return None
+        # A wildcard entry describes every container of its kind, so its name
+        # has to carry the index or every zone ends up with the same name.
+        index = catalog_container_index(capability)
+        if index and entry.friendly_name and CATALOG_INDEX_PLACEHOLDER in entry.friendly_name:
+            return replace(entry, friendly_name=entry.friendly_name.format(index=index))
+        return entry
 
     def update_missing_entities(self) -> None:
         """Add missing entities when no capabilities returned by the API.

--- a/custom_components/electrolux_status/api.py
+++ b/custom_components/electrolux_status/api.py
@@ -667,19 +667,35 @@ class Appliance:
             # not required by each device type (fridge, dryer, vacumn etc are all different)
             _LOGGER.warning("Electrolux API returned no capability definition")
 
-        # Add static attribute
-        # these are attributes that are not in the capability entry
-        # but are returned by the api independantly
+        # For each capability src
+        if capabilities_names:
+            for capability in capabilities_names:
+                if entity := self.get_entity(capability):
+                    entities.extend(entity)
+                else:
+                    _LOGGER.debug("Could not create entity for capability %s", capability)
+
+        # Add static attributes: attributes the API reports but does not
+        # advertise as capabilities.
+        #
+        # Done after the capability pass and keyed on what that pass actually
+        # produced, not on whether the name appears in the capability document.
+        # An attribute can be advertised and still yield no entity - when the
+        # walker cannot classify its type - and it would then be lost if this
+        # skipped on the name alone. Where the capability pass did build one,
+        # skipping is required: the two would share a unique id.
+        built = {(entity.entity_attr, entity.entity_source) for entity in entities}
         for static_attribute in STATIC_ATTRIBUTES:
             _LOGGER.debug("Electrolux static_attribute %s", static_attribute)
             # attr not found in state, next attr
             if self.get_state(static_attribute) is None:
                 continue
-            if capabilities_names and static_attribute in capabilities_names:
-                # Both entities would share one unique id, and HA drops the
-                # second. Let the capability document drive it.
+            if (
+                self.data.get_entity_attr(static_attribute),
+                self.data.get_category(static_attribute),
+            ) in built:
                 _LOGGER.debug(
-                    "Electrolux static_attribute %s also advertised as a capability, skipping",
+                    "Electrolux static_attribute %s already built from the capability document",
                     static_attribute,
                 )
                 continue
@@ -696,14 +712,6 @@ class Appliance:
                 capabilities[keys[-1]] = catalog_item.capability_info
                 _LOGGER.debug("Electrolux adding static_attribute %s", static_attribute)
                 entities.extend(entity)
-
-        # For each capability src
-        if capabilities_names:
-            for capability in capabilities_names:
-                if entity := self.get_entity(capability):
-                    entities.extend(entity)
-                else:
-                    _LOGGER.debug("Could not create entity for capability %s", capability)
 
         # Setup each found entity
         self.entities = entities

--- a/custom_components/electrolux_status/catalog_core.py
+++ b/custom_components/electrolux_status/catalog_core.py
@@ -14,9 +14,19 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.entity import EntityCategory
 
+from .catalog_hob import HB
 from .catalog_purifier import A9
 from .catalog_refrigerator import EHE6899SA
 from .model import ElectroluxDevice
+
+# definitions of appliance-type explicit overrides, keyed by the
+# applianceInfo/applianceType reported by the appliance (HB = hob,
+# WM = washing machine, TD = tumble dryer, CR = refrigerator, ...).
+# Prefer this over CATALOG_MODEL: it applies to every model of a
+# given type instead of a single sales code.
+CATALOG_APPLIANCE_TYPE: dict[str, dict[str, ElectroluxDevice]] = {
+    "HB": HB,
+}
 
 # definitions of model explicit overrides. These will be used to
 # create a new catalog with a merged definition of properties

--- a/custom_components/electrolux_status/catalog_hob.py
+++ b/custom_components/electrolux_status/catalog_hob.py
@@ -1,0 +1,232 @@
+"""Defined catalog of entities for hob (HB) type devices.
+
+Every entry here only supplies presentation metadata (friendly name, device
+class, unit, icon, category) or a deliberate platform override. Whether a
+capability exists at all, its access mode, its enum values and its numeric
+bounds all remain owned by the capability document returned by the API.
+
+Keys may use a ``*`` wildcard in place of the numeric suffix of a container,
+e.g. ``hobZone*/runningTime``. Hobs report a variable and non-contiguous set of
+zones (the AEG CCE84779CB reports hobZone1-4 plus hobZone7-8 for its bridged
+zones), so entries must never be written against a fixed zone count.
+"""
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.number import NumberDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import Platform, UnitOfTime
+from homeassistant.helpers.entity import EntityCategory
+
+from .model import ElectroluxDevice
+
+HB: dict[str, ElectroluxDevice] = {
+    #
+    # Appliance level
+    #
+    "applianceState": ElectroluxDevice(
+        capability_info={"access": "read", "type": "string"},
+        entity_icon="mdi:stove",
+        # Unlike a washer/dryer cycle state, the hob state is the primary
+        # thing a user wants on a dashboard, so enable it by default.
+        entity_registry_enabled_default=True,
+    ),
+    "childLock": ElectroluxDevice(
+        friendly_name="Child lock",
+        capability_info={"access": "read", "type": "boolean"},
+        device_class=BinarySensorDeviceClass.LOCK,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:account-lock",
+        # BinarySensorDeviceClass.LOCK is "on == unlocked", the appliance
+        # reports "true == locked".
+        state_invert=True,
+        entity_platform=Platform.BINARY_SENSOR,
+    ),
+    "uiLockMode": ElectroluxDevice(
+        friendly_name="Control panel lock",
+        # The HB capability document reports uiLockMode as access "read".
+        # CATALOG_BASE models it as a writable switch for other appliance
+        # types; override it back to a read-only binary sensor here so the
+        # integration never offers an action the hob will not honour.
+        capability_info={"access": "read", "type": "boolean"},
+        device_class=BinarySensorDeviceClass.LOCK,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:lock",
+        state_invert=True,
+        entity_platform=Platform.BINARY_SENSOR,
+    ),
+    "keySoundTone": ElectroluxDevice(
+        friendly_name="Key sound tone",
+        entity_category=EntityCategory.CONFIG,
+        entity_icon="mdi:volume-high",
+    ),
+    "keyModel": ElectroluxDevice(
+        friendly_name="Key model",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:identifier",
+        entity_registry_enabled_default=False,
+    ),
+    #
+    # Integrated extractor / hood
+    #
+    "hobHood/hobToHoodFanSpeed": ElectroluxDevice(
+        friendly_name="Extractor fan speed",
+        entity_icon="mdi:fan",
+    ),
+    "hobHood/hobToHoodState": ElectroluxDevice(
+        friendly_name="Extractor mode",
+        entity_icon="mdi:auto-mode",
+    ),
+    "hobHood/hobToHoodMode": ElectroluxDevice(
+        friendly_name="Extractor hob-to-hood level",
+        entity_category=EntityCategory.CONFIG,
+        entity_icon="mdi:tune-variant",
+    ),
+    "hobHood/targetDuration": ElectroluxDevice(
+        friendly_name="Extractor run-on duration",
+        device_class=NumberDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        entity_icon="mdi:timer-cog",
+    ),
+    "hobHood/timeToEnd": ElectroluxDevice(
+        friendly_name="Extractor time to end",
+        device_class=SensorDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        entity_icon="mdi:timer-sand",
+    ),
+    "hobHood/windowNotification": ElectroluxDevice(
+        friendly_name="Window notification",
+        entity_icon="mdi:window-open-variant",
+    ),
+    "hobHood/hoodFilterCharcIndication": ElectroluxDevice(
+        friendly_name="Charcoal filter",
+        # Reported as access "readwrite" (the appliance allows resetting the
+        # indication), but a switch would imply that saturation itself can be
+        # turned on. Expose the state only; a reset button can follow later.
+        capability_info={"access": "read", "type": "boolean"},
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:air-filter",
+        entity_platform=Platform.BINARY_SENSOR,
+    ),
+    "hobHood/hoodFilterGreaseIndication": ElectroluxDevice(
+        friendly_name="Grease filter",
+        capability_info={"access": "read", "type": "boolean"},
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:air-filter",
+        entity_platform=Platform.BINARY_SENSOR,
+    ),
+    #
+    # Cooking zones. Wildcard keys, one entity per zone the device reports.
+    #
+    "hobZone*/heatingQualitativeLevel": ElectroluxDevice(
+        friendly_name="Power level",
+        # Deliberately read-only. See MODULE NOTE at the bottom of this file.
+        entity_icon="mdi:stove",
+        entity_platform=Platform.SENSOR,
+    ),
+    "hobZone*/hobPotDetected": ElectroluxDevice(
+        friendly_name="Pot detection",
+        # Kept as a four-state enum sensor rather than a binary sensor:
+        # NO_POT_IDLE / NO_POT_RUNNING / POT_IDLE / POT_RUNNING carries both
+        # pot presence and whether the zone is running, which a binary sensor
+        # would throw away.
+        entity_icon="mdi:pot-steam",
+    ),
+    "hobZone*/residualHeatState": ElectroluxDevice(
+        friendly_name="Residual heat",
+        entity_icon="mdi:heat-wave",
+    ),
+    "hobZone*/runningTime": ElectroluxDevice(
+        friendly_name="Running time",
+        device_class=SensorDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        entity_icon="mdi:timelapse",
+    ),
+    "hobZone*/timeToEnd": ElectroluxDevice(
+        friendly_name="Time to end",
+        device_class=SensorDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        entity_icon="mdi:timer-sand",
+    ),
+    "hobZone*/targetDuration": ElectroluxDevice(
+        friendly_name="Target duration",
+        device_class=SensorDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        entity_icon="mdi:timer-cog",
+        # Read-only: see MODULE NOTE.
+        entity_platform=Platform.SENSOR,
+    ),
+    "hobZone*/reminderTime": ElectroluxDevice(
+        friendly_name="Reminder time",
+        device_class=SensorDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:timer-alert",
+        entity_platform=Platform.SENSOR,
+    ),
+    "hobZone*/hobMaxPowerLevel": ElectroluxDevice(
+        friendly_name="Max power level",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:speedometer",
+        entity_registry_enabled_default=False,
+    ),
+    "hobZone*/hobCoil": ElectroluxDevice(
+        friendly_name="Coil",
+        # Declared as a number by the capability document but reported as an
+        # empty object by the appliance, so it has no displayable value.
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:coil",
+        entity_registry_enabled_default=False,
+    ),
+    #
+    # Heating modules (flexible/bridge zones)
+    #
+    "hobModule*/heatingModuleType": ElectroluxDevice(
+        friendly_name="Heating module type",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:chip",
+        entity_registry_enabled_default=False,
+    ),
+    "hobModule*/hobFrontZone": ElectroluxDevice(
+        friendly_name="Front zone",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:square-rounded",
+    ),
+    "hobModule*/hobMiddleZone": ElectroluxDevice(
+        friendly_name="Middle zone",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:square-rounded",
+    ),
+    "hobModule*/hobRearZone": ElectroluxDevice(
+        friendly_name="Rear zone",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:square-rounded",
+    ),
+    "hobModule*/procookLevelFront": ElectroluxDevice(
+        friendly_name="ProCook level front",
+        # Read-only: see MODULE NOTE.
+        entity_icon="mdi:stove",
+        entity_platform=Platform.SENSOR,
+    ),
+    "hobModule*/procookLevelRear": ElectroluxDevice(
+        friendly_name="ProCook level rear",
+        entity_icon="mdi:stove",
+        entity_platform=Platform.SENSOR,
+    ),
+}
+
+# MODULE NOTE — why cooking power is exposed read-only
+#
+# The CCE84779CB capability document reports a handful of cooking controls as
+# writable: hobZone1/heatingQualitativeLevel (0-9), hobZone3/targetDuration and
+# hobModule1-2/procookLevelFront|Rear. The equivalent properties on every other
+# zone are read-only, which makes the writable set look like an inconsistency in
+# the appliance's capability document rather than a supported feature.
+#
+# Turning a burner on remotely is also safety-relevant: the appliance reports
+# remoteControl = NOT_SAFETY_RELEVANT_ENABLED, meaning it only accepts remote
+# commands that are not safety-relevant. These entities are therefore pinned to
+# read-only sensors until Electrolux documents remote cooking control and the
+# maintainers decide they want it. Removing the entity_platform override on the
+# entries above is all that is needed to revisit that decision.

--- a/custom_components/electrolux_status/catalog_hob.py
+++ b/custom_components/electrolux_status/catalog_hob.py
@@ -207,13 +207,13 @@ HB: dict[str, ElectroluxDevice] = {
         entity_icon="mdi:square-rounded",
     ),
     "hobModule*/procookLevelFront": ElectroluxDevice(
-        friendly_name="Module {index} ProCook level front",
+        friendly_name="Module {index} Procook level front",
         # Read-only: see MODULE NOTE.
         entity_icon="mdi:stove",
         entity_platform=Platform.SENSOR,
     ),
     "hobModule*/procookLevelRear": ElectroluxDevice(
-        friendly_name="Module {index} ProCook level rear",
+        friendly_name="Module {index} Procook level rear",
         entity_icon="mdi:stove",
         entity_platform=Platform.SENSOR,
     ),

--- a/custom_components/electrolux_status/catalog_hob.py
+++ b/custom_components/electrolux_status/catalog_hob.py
@@ -6,7 +6,10 @@ capability exists at all, its access mode, its enum values and its numeric
 bounds all remain owned by the capability document returned by the API.
 
 Keys may use a ``*`` wildcard in place of the numeric suffix of a container,
-e.g. ``hobZone*/runningTime``. Hobs report a variable and non-contiguous set of
+e.g. ``hobZone*/runningTime``. Such an entry describes every container of its
+kind, so its ``friendly_name`` must carry the ``{index}`` placeholder - it is
+replaced with the container's number, otherwise every zone would present the
+same name to the UI, to search and to voice assistants. Hobs report a variable and non-contiguous set of
 zones (the AEG CCE84779CB reports hobZone1-4 plus hobZone7-8 for its bridged
 zones), so entries must never be written against a fixed zone count.
 """
@@ -120,13 +123,13 @@ HB: dict[str, ElectroluxDevice] = {
     # Cooking zones. Wildcard keys, one entity per zone the device reports.
     #
     "hobZone*/heatingQualitativeLevel": ElectroluxDevice(
-        friendly_name="Power level",
+        friendly_name="Zone {index} power level",
         # Deliberately read-only. See MODULE NOTE at the bottom of this file.
         entity_icon="mdi:stove",
         entity_platform=Platform.SENSOR,
     ),
     "hobZone*/hobPotDetected": ElectroluxDevice(
-        friendly_name="Pot detection",
+        friendly_name="Zone {index} pot detection",
         # Kept as a four-state enum sensor rather than a binary sensor:
         # NO_POT_IDLE / NO_POT_RUNNING / POT_IDLE / POT_RUNNING carries both
         # pot presence and whether the zone is running, which a binary sensor
@@ -134,23 +137,23 @@ HB: dict[str, ElectroluxDevice] = {
         entity_icon="mdi:pot-steam",
     ),
     "hobZone*/residualHeatState": ElectroluxDevice(
-        friendly_name="Residual heat",
+        friendly_name="Zone {index} residual heat",
         entity_icon="mdi:heat-wave",
     ),
     "hobZone*/runningTime": ElectroluxDevice(
-        friendly_name="Running time",
+        friendly_name="Zone {index} running time",
         device_class=SensorDeviceClass.DURATION,
         unit=UnitOfTime.SECONDS,
         entity_icon="mdi:timelapse",
     ),
     "hobZone*/timeToEnd": ElectroluxDevice(
-        friendly_name="Time to end",
+        friendly_name="Zone {index} time to end",
         device_class=SensorDeviceClass.DURATION,
         unit=UnitOfTime.SECONDS,
         entity_icon="mdi:timer-sand",
     ),
     "hobZone*/targetDuration": ElectroluxDevice(
-        friendly_name="Target duration",
+        friendly_name="Zone {index} target duration",
         device_class=SensorDeviceClass.DURATION,
         unit=UnitOfTime.SECONDS,
         entity_icon="mdi:timer-cog",
@@ -158,7 +161,7 @@ HB: dict[str, ElectroluxDevice] = {
         entity_platform=Platform.SENSOR,
     ),
     "hobZone*/reminderTime": ElectroluxDevice(
-        friendly_name="Reminder time",
+        friendly_name="Zone {index} reminder time",
         device_class=SensorDeviceClass.DURATION,
         unit=UnitOfTime.SECONDS,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -166,13 +169,13 @@ HB: dict[str, ElectroluxDevice] = {
         entity_platform=Platform.SENSOR,
     ),
     "hobZone*/hobMaxPowerLevel": ElectroluxDevice(
-        friendly_name="Max power level",
+        friendly_name="Zone {index} max power level",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_icon="mdi:speedometer",
         entity_registry_enabled_default=False,
     ),
     "hobZone*/hobCoil": ElectroluxDevice(
-        friendly_name="Coil",
+        friendly_name="Zone {index} coil",
         # Declared as a number by the capability document but reported as an
         # empty object by the appliance, so it has no displayable value.
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -183,34 +186,34 @@ HB: dict[str, ElectroluxDevice] = {
     # Heating modules (flexible/bridge zones)
     #
     "hobModule*/heatingModuleType": ElectroluxDevice(
-        friendly_name="Heating module type",
+        friendly_name="Module {index} heating module type",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_icon="mdi:chip",
         entity_registry_enabled_default=False,
     ),
     "hobModule*/hobFrontZone": ElectroluxDevice(
-        friendly_name="Front zone",
+        friendly_name="Module {index} front zone",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_icon="mdi:square-rounded",
     ),
     "hobModule*/hobMiddleZone": ElectroluxDevice(
-        friendly_name="Middle zone",
+        friendly_name="Module {index} middle zone",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_icon="mdi:square-rounded",
     ),
     "hobModule*/hobRearZone": ElectroluxDevice(
-        friendly_name="Rear zone",
+        friendly_name="Module {index} rear zone",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_icon="mdi:square-rounded",
     ),
     "hobModule*/procookLevelFront": ElectroluxDevice(
-        friendly_name="ProCook level front",
+        friendly_name="Module {index} ProCook level front",
         # Read-only: see MODULE NOTE.
         entity_icon="mdi:stove",
         entity_platform=Platform.SENSOR,
     ),
     "hobModule*/procookLevelRear": ElectroluxDevice(
-        friendly_name="ProCook level rear",
+        friendly_name="Module {index} ProCook level rear",
         entity_icon="mdi:stove",
         entity_platform=Platform.SENSOR,
     ),

--- a/custom_components/electrolux_status/entity.py
+++ b/custom_components/electrolux_status/entity.py
@@ -223,6 +223,21 @@ class ElectroluxEntity(CoordinatorEntity):
                     return root.get(attribute, None)
         return None
 
+    def apply_value_mapping(self, value: Any) -> Any:
+        """Translate a raw value through the catalog's value_mapping.
+
+        Some capabilities are described with string values but reported as
+        integers; the mapping converts them back. Shared by every platform that
+        displays a catalog-mapped value.
+        """
+        if value is None or not self.catalog_entry or not self.catalog_entry.value_mapping:
+            return value
+        mapping = self.catalog_entry.value_mapping
+        if value in mapping:
+            _LOGGER.debug("Mapping %s: %s to %s", self.json_path, value, mapping)
+            return mapping.get(value, value)
+        return value
+
     def update(self, appliance_status: ApplienceStatusResponse):
         """Update the appliance status."""
         self.appliance_status = appliance_status

--- a/custom_components/electrolux_status/number.py
+++ b/custom_components/electrolux_status/number.py
@@ -51,11 +51,15 @@ class ElectroluxNumber(ElectroluxEntity, NumberEntity):
         else:
             value = self.extract_value()
 
-        if not value:
+        # Test for None rather than falsiness: 0 is a legitimate reading, and
+        # treating it as missing made any number whose value and default are
+        # both 0 fall through to an empty cache and render as unknown. The
+        # hob's extractor run-on duration does exactly that when it is unset.
+        if value is None:
             value = self.capability.get("default", None)
             if value == "INVALID_OR_NOT_SET_TIME":
                 value = self.capability.get("min", None)
-        if not value:
+        if value is None:
             return self._cached_value
         if isinstance(self.unit, UnitOfTemperature):
             value = round(value, 2)

--- a/custom_components/electrolux_status/select.py
+++ b/custom_components/electrolux_status/select.py
@@ -76,13 +76,17 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
         )
         values_dict: dict[str, Any] | None = self.capability.get("values", None)
         self.options_list: dict[str, str] = {}
+        # Values the appliance can report but refuses to be set to. They are
+        # kept out of the selectable options while still being displayable,
+        # e.g. a hob hood reports hobToHoodState AUTO_SUSPEND but marks it
+        # disabled in its capability document.
+        self.readonly_options: set[str] = set()
         for value in values_dict:
             entry: dict[str, Any] = values_dict[value]
-            if "disabled" in entry:
-                continue
-
             label = self.format_label(value)
             self.options_list[label] = value
+            if "disabled" in entry:
+                self.readonly_options.add(label)
 
     @property
     def entity_domain(self):
@@ -132,10 +136,12 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
                 self.options_list.values(),
                 ex,
             )
-        # When value not in the catalog -> add the value to the list then
+        # When value not in the catalog -> add the value for display only.
+        # It was not advertised as settable, so do not make it selectable.
         if label is None:
             label = self.format_label(value)
             self.options_list[label] = value
+            self.readonly_options.add(label)
         if label is not None:
             self._cached_value = label
         else:
@@ -144,6 +150,13 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
+        if option in self.readonly_options:
+            _LOGGER.warning(
+                "Electrolux %s cannot be set to %s: the appliance reports that value as disabled",
+                self.json_path,
+                option,
+            )
+            return
         value = self.options_list.get(option, None)
         if (
             isinstance(self.unit, UnitOfTemperature)
@@ -182,5 +195,10 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
 
     @property
     def options(self) -> list[str]:
-        """Return a set of selectable options."""
-        return list(self.options_list.keys())
+        """Return a set of selectable options.
+
+        Excludes values the capability document marks as disabled. The current
+        option may still report one of those, which is the honest reading of an
+        appliance that enters a state it will not let you select.
+        """
+        return [label for label in self.options_list if label not in self.readonly_options]

--- a/custom_components/electrolux_status/select.py
+++ b/custom_components/electrolux_status/select.py
@@ -10,6 +10,7 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, Platform, UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, SELECT
@@ -112,19 +113,29 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
     #         return "mdi:XXX"
     #     return "mdi:YYY"
 
-    @property
-    def current_option(self) -> str:
-        """Return the current option."""
+    def reported_value(self) -> Any:
+        """Return the reported value with any catalog mapping applied.
+
+        Shared by current_option and options so the two cannot disagree about
+        which option the appliance is currently reporting.
+        """
         value = self.extract_value()
-
         if value is None:
-            return self._cached_value
-
+            return None
         if self.catalog_entry and self.catalog_entry.value_mapping:
             mapping = self.catalog_entry.value_mapping
             _LOGGER.debug("Mapping %s: %s to %s", self.json_path, value, mapping)
             if value in mapping:
                 value = mapping.get(value, value)
+        return value
+
+    @property
+    def current_option(self) -> str:
+        """Return the current option."""
+        value = self.reported_value()
+
+        if value is None:
+            return self._cached_value
 
         label = None
         try:
@@ -136,12 +147,13 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
                 self.options_list.values(),
                 ex,
             )
-        # When value not in the catalog -> add the value for display only.
-        # It was not advertised as settable, so do not make it selectable.
+        # Electrolux capability documents omit values that appliances really
+        # do report, which is why this fallback exists. Learn the value and
+        # leave it selectable - only values the document explicitly flags as
+        # disabled are withheld.
         if label is None:
             label = self.format_label(value)
             self.options_list[label] = value
-            self.readonly_options.add(label)
         if label is not None:
             self._cached_value = label
         else:
@@ -151,12 +163,11 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         if option in self.readonly_options:
-            _LOGGER.warning(
-                "Electrolux %s cannot be set to %s: the appliance reports that value as disabled",
-                self.json_path,
-                option,
+            # Reachable from a script: the value is in options while the
+            # appliance reports it, so HA's own validation lets it through.
+            raise ServiceValidationError(
+                f"{self.name} cannot be set to {option}: the appliance reports that value as disabled"
             )
-            return
         value = self.options_list.get(option, None)
         if (
             isinstance(self.unit, UnitOfTemperature)
@@ -206,7 +217,7 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
         refused by async_select_option, so it can be seen but never chosen.
         """
         selectable = [label for label in self.options_list if label not in self.readonly_options]
-        value = self.extract_value()
+        value = self.reported_value()
         for label in self.readonly_options:
             if self.options_list.get(label) == value and label not in selectable:
                 selectable.append(label)

--- a/custom_components/electrolux_status/select.py
+++ b/custom_components/electrolux_status/select.py
@@ -208,9 +208,10 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
         """
         if not self.readonly_options:
             return list(self.options_list)
-        value = self.reported_value()
-        return [
-            label
-            for label, option in self.options_list.items()
-            if label not in self.readonly_options or option == value
-        ]
+        # Compare against current_option rather than the reported value, so the
+        # two cannot disagree. current_option falls back to the last known
+        # label when a payload omits the attribute, and a disabled value has to
+        # survive that fallback too - otherwise the entity renders as unknown
+        # the first time an update arrives without it.
+        current = self.current_option
+        return [label for label in self.options_list if label not in self.readonly_options or label == current]

--- a/custom_components/electrolux_status/select.py
+++ b/custom_components/electrolux_status/select.py
@@ -82,10 +82,14 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
         # e.g. a hob hood reports hobToHoodState AUTO_SUSPEND but marks it
         # disabled in its capability document.
         self.readonly_options: set[str] = set()
+        # Reverse index, so resolving the reported value to its label is a dict
+        # lookup rather than a scan of every option on each state write.
+        self.label_by_value: dict[Any, str] = {}
         for value in values_dict:
             entry: dict[str, Any] = values_dict[value]
             label = self.format_label(value)
             self.options_list[label] = value
+            self.label_by_value[value] = label
             if "disabled" in entry:
                 self.readonly_options.add(label)
 
@@ -119,15 +123,7 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
         Shared by current_option and options so the two cannot disagree about
         which option the appliance is currently reporting.
         """
-        value = self.extract_value()
-        if value is None:
-            return None
-        if self.catalog_entry and self.catalog_entry.value_mapping:
-            mapping = self.catalog_entry.value_mapping
-            _LOGGER.debug("Mapping %s: %s to %s", self.json_path, value, mapping)
-            if value in mapping:
-                value = mapping.get(value, value)
-        return value
+        return self.apply_value_mapping(self.extract_value())
 
     @property
     def current_option(self) -> str:
@@ -137,27 +133,21 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
         if value is None:
             return self._cached_value
 
-        label = None
-        try:
-            label = list(self.options_list.keys())[list(self.options_list.values()).index(value)]
-        except Exception as ex:  # noqa: BLE001
-            _LOGGER.info(
-                "Electrolux error value %s does not exist in the list %s. %s",
-                value,
-                self.options_list.values(),
-                ex,
-            )
+        label = self.label_by_value.get(value)
         # Electrolux capability documents omit values that appliances really
         # do report, which is why this fallback exists. Learn the value and
         # leave it selectable - only values the document explicitly flags as
         # disabled are withheld.
         if label is None:
+            _LOGGER.info(
+                "Electrolux %s reported %s, which its capabilities do not list; adding it",
+                self.json_path,
+                value,
+            )
             label = self.format_label(value)
             self.options_list[label] = value
-        if label is not None:
-            self._cached_value = label
-        else:
-            label = self._cached_value
+            self.label_by_value[value] = label
+        self._cached_value = label
         return label
 
     async def async_select_option(self, option: str) -> None:
@@ -216,9 +206,11 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
         sitting in AUTO_SUSPEND would show as "unknown". Sending it is still
         refused by async_select_option, so it can be seen but never chosen.
         """
-        selectable = [label for label in self.options_list if label not in self.readonly_options]
+        if not self.readonly_options:
+            return list(self.options_list)
         value = self.reported_value()
-        for label in self.readonly_options:
-            if self.options_list.get(label) == value and label not in selectable:
-                selectable.append(label)
-        return selectable
+        return [
+            label
+            for label, option in self.options_list.items()
+            if label not in self.readonly_options or option == value
+        ]

--- a/custom_components/electrolux_status/select.py
+++ b/custom_components/electrolux_status/select.py
@@ -197,8 +197,17 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
     def options(self) -> list[str]:
         """Return a set of selectable options.
 
-        Excludes values the capability document marks as disabled. The current
-        option may still report one of those, which is the honest reading of an
-        appliance that enters a state it will not let you select.
+        Values the capability document marks as disabled are not offered.
+
+        Home Assistant renders no state at all for a select whose current
+        option is absent from this list, so a disabled value is kept in the
+        list while the appliance is actually reporting it - otherwise a hob
+        sitting in AUTO_SUSPEND would show as "unknown". Sending it is still
+        refused by async_select_option, so it can be seen but never chosen.
         """
-        return [label for label in self.options_list if label not in self.readonly_options]
+        selectable = [label for label in self.options_list if label not in self.readonly_options]
+        value = self.extract_value()
+        for label in self.readonly_options:
+            if self.options_list.get(label) == value and label not in selectable:
+                selectable.append(label)
+        return selectable

--- a/custom_components/electrolux_status/sensor.py
+++ b/custom_components/electrolux_status/sensor.py
@@ -67,13 +67,9 @@ class ElectroluxSensor(ElectroluxEntity, SensorEntity):
         elif value is not None and isinstance(self.unit, UnitOfTime):
             # Electrolux bug - prevent negative/disabled timers
             value = max(value, 0)
-        if self.catalog_entry and self.catalog_entry.value_mapping:
-            # Electrolux presents as string but returns an int
-            # the mapping entry allows us to correctly display this to the frontend
-            mapping = self.catalog_entry.value_mapping
-            _LOGGER.debug("Mapping %s: %s to %s", self.json_path, value, mapping)
-            if value in mapping:
-                value = mapping.get(value, value)
+        # Electrolux presents as string but returns an int; the mapping entry
+        # allows us to correctly display this to the frontend
+        value = self.apply_value_mapping(value)
         if isinstance(value, str):
             if "_" in value:
                 value = value.replace("_", " ")

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,8 @@
+# Test-only dependencies. The integration's own runtime requirements are
+# declared in custom_components/electrolux_status/manifest.json.
+homeassistant
+pytest
+
+# Mirrors manifest.json, needed to import the integration under test.
+pyelectroluxocp==0.1.3
+aiofiles==25.1.0

--- a/samples/CCE84779CB/get_appliance_capabilities.json
+++ b/samples/CCE84779CB/get_appliance_capabilities.json
@@ -1,0 +1,964 @@
+{
+  "alerts": {
+    "access": "read",
+    "type": "alert",
+    "values": {
+      "CKG_ZONE_FAIL_E601": {},
+      "CKG_ZONE_FAIL_E602": {},
+      "CKG_ZONE_FAIL_E603": {},
+      "CKG_ZONE_FAIL_E604": {},
+      "CKG_ZONE_FAIL_E605": {},
+      "CKG_ZONE_FAIL_E606": {},
+      "CKG_ZONE_FAIL_E611": {},
+      "CKG_ZONE_FAIL_E612": {},
+      "CKG_ZONE_FAIL_E613": {},
+      "CKG_ZONE_FAIL_E614": {},
+      "CKG_ZONE_FAIL_E615": {},
+      "CKG_ZONE_FAIL_E616": {},
+      "CKG_ZONE_FAIL_E621": {},
+      "CKG_ZONE_FAIL_E622": {},
+      "CKG_ZONE_FAIL_E623": {},
+      "CKG_ZONE_FAIL_E624": {},
+      "CKG_ZONE_FAIL_E625": {},
+      "CKG_ZONE_FAIL_E626": {},
+      "CKG_ZONE_FAIL_E651": {},
+      "CKG_ZONE_FAIL_E652": {},
+      "CKG_ZONE_FAIL_E653": {},
+      "CKG_ZONE_FAIL_E654": {},
+      "CKG_ZONE_FAIL_E655": {},
+      "CKG_ZONE_FAIL_E656": {},
+      "CKG_ZONE_FAN_FAIL_E701": {},
+      "CKG_ZONE_FAN_FAIL_E702": {},
+      "CKG_ZONE_FAN_FAIL_E703": {},
+      "CKG_ZONE_FAN_FAIL_E704": {},
+      "CKG_ZONE_FAN_FAIL_E705": {},
+      "CKG_ZONE_FAN_FAIL_E706": {},
+      "CKG_ZONE_FAN_FAIL_E711": {},
+      "CKG_ZONE_FAN_FAIL_E712": {},
+      "CKG_ZONE_FAN_FAIL_E713": {},
+      "CKG_ZONE_FAN_FAIL_E714": {},
+      "CKG_ZONE_FAN_FAIL_E715": {},
+      "CKG_ZONE_FAN_FAIL_E716": {},
+      "CKG_ZONE_SW_ERROR_E011": {},
+      "CKG_ZONE_SW_ERROR_E012": {},
+      "CKG_ZONE_SW_ERROR_E013": {},
+      "CKG_ZONE_SW_ERROR_E014": {},
+      "CKG_ZONE_SW_ERROR_E015": {},
+      "CKG_ZONE_SW_ERROR_E016": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E401": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E402": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E403": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E404": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E405": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E406": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E411": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E412": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E413": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E414": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E415": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E416": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E431": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E432": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E433": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E434": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E435": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E436": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E441": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E442": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E443": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E444": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E445": {},
+      "CKG_ZONE_TEMP_SENS_FAIL_E446": {},
+      "CKG_ZONE_TEMP_TOO_HIGH_E421": {},
+      "CKG_ZONE_TEMP_TOO_HIGH_E422": {},
+      "CKG_ZONE_TEMP_TOO_HIGH_E423": {},
+      "CKG_ZONE_TEMP_TOO_HIGH_E424": {},
+      "CKG_ZONE_TEMP_TOO_HIGH_E425": {},
+      "CKG_ZONE_TEMP_TOO_HIGH_E426": {},
+      "DATA_CRC_ERROR_E661": {},
+      "DATA_CRC_ERROR_E662": {},
+      "DATA_CRC_ERROR_E663": {},
+      "DISPLAY_ELECTRONIC_FAIL_E061": {},
+      "DISPLAY_ELECTRONIC_FAIL_E081": {},
+      "DISPLAY_ELECTRONIC_FAIL_E091": {},
+      "DISPLAY_ELECTRONIC_FAIL_E0C1": {},
+      "DISPLAY_NOT_PROPER_WORK_E9F1": {},
+      "DISPLAY_TEMP_TOO_HIGH_E0A1": {},
+      "HOOD_FAIL_E518": {},
+      "HOOD_FAIL_E527": {},
+      "HOOD_FAIL_E528": {},
+      "HOOD_FAIL_E8B1": {},
+      "HOOD_MC_BOARD_ALARM_E537": {},
+      "HOOD_SW_FAIL_E517": {},
+      "HUI_PIXIE_COMM_ALARM_E8B7": {},
+      "INTERNAL_COMM_FAIL_E821": {},
+      "INTERNAL_COMM_FAIL_E822": {},
+      "INTERNAL_COMM_FAIL_E823": {},
+      "INTERNAL_COMM_FAIL_E824": {},
+      "INTERNAL_COMM_FAIL_E825": {},
+      "INTERNAL_COMM_FAIL_E826": {},
+      "INTERNAL_COMM_FAIL_E831": {},
+      "INTERNAL_COMM_FAIL_E841": {},
+      "INTERNAL_COMM_FAIL_E851": {},
+      "INTERNAL_COMM_FAIL_E861": {},
+      "INTERNAL_COMM_FAIL_E871": {},
+      "KEY_ERROR_FMEA_E9D1": {},
+      "KNOB_ERROR_E951": {},
+      "MAINS_CONNECTION_ERROR_E311": {},
+      "MAINS_CONNECTION_ERROR_E312": {},
+      "MAINS_CONNECTION_ERROR_E313": {},
+      "MAINS_CONNECTION_ERROR_E314": {},
+      "MAINS_CONNECTION_ERROR_E315": {},
+      "MAINS_CONNECTION_ERROR_E316": {},
+      "MAINS_RELAY_FAIL_E641": {},
+      "MAINS_RELAY_FAIL_E642": {},
+      "MAINS_RELAY_FAIL_E643": {},
+      "MAINS_RELAY_FAIL_E644": {},
+      "MAINS_RELAY_FAIL_E645": {},
+      "MAINS_RELAY_FAIL_E646": {},
+      "MAINS_VOLTAGE_TOO_LOW_E321": {},
+      "MAINS_VOLTAGE_TOO_LOW_E322": {},
+      "MAINS_VOLTAGE_TOO_LOW_E323": {},
+      "MAINS_VOLTAGE_TOO_LOW_E324": {},
+      "MAINS_VOLTAGE_TOO_LOW_E325": {},
+      "MAINS_VOLTAGE_TOO_LOW_E326": {},
+      "SENSEBOIL_FAIL_E272": {},
+      "SENSEBOIL_FAIL_E282": {},
+      "SENSEBOIL_FAIL_E8A2": {},
+      "SW_ERROR_E021": {},
+      "SW_ERROR_E031": {},
+      "SW_ERROR_E041": {},
+      "SW_ERROR_E051": {},
+      "TOUCH_NOT_PROPER_WORK_E911": {},
+      "TOUCH_NOT_PROPER_WORK_E921": {},
+      "TOUCH_NOT_PROPER_WORK_E931": {},
+      "TOUCH_NOT_PROPER_WORK_E941": {},
+      "TOUCH_NOT_PROPER_WORK_E961": {},
+      "TOUCH_NOT_PROPER_WORK_E971": {},
+      "TOUCH_NOT_PROPER_WORK_E981": {},
+      "TOUCH_NOT_PROPER_WORK_E991": {},
+      "TOUCH_NOT_PROPER_WORK_E9A1": {},
+      "TOUCH_NOT_PROPER_WORK_E9B1": {},
+      "TOUCH_NOT_PROPER_WORK_E9C1": {},
+      "WI-FI_FAIL_E141": {},
+      "WI-FI_FAIL_E181": {},
+      "ZONE_ILLUMINATION_FAIL_E201": {},
+      "ZONE_ILLUMINATION_FAIL_E211": {},
+      "ZONE_ILLUMINATION_FAIL_E221": {},
+      "ZONE_ILLUMINATION_FAIL_E231": {},
+      "ZONE_ILLUMINATION_FAIL_E241": {}
+    }
+  },
+  "applianceMode": {
+    "access": "read",
+    "type": "string",
+    "values": {
+      "DEMO": {},
+      "DIAGNOSTIC": {},
+      "NORMAL": {},
+      "SERVICE": {}
+    }
+  },
+  "applianceState": {
+    "access": "read",
+    "type": "string",
+    "values": {
+      "ALARM": {},
+      "IDLE": {},
+      "OFF": {},
+      "PAUSED": {},
+      "RUNNING": {}
+    }
+  },
+  "childLock": {
+    "access": "readwrite",
+    "triggers": [
+      {
+        "action": {
+          "$self": {
+            "access": "read"
+          }
+        },
+        "condition": {
+          "operand_1": "value",
+          "operand_2": "ENABLED",
+          "operator": "eq"
+        }
+      },
+      {
+        "action": {
+          "$self": {
+            "access": "readwrite"
+          }
+        },
+        "condition": {
+          "operand_1": "value",
+          "operand_2": "DISABLED",
+          "operator": "eq"
+        }
+      }
+    ],
+    "type": "boolean",
+    "values": {
+      "DISABLED": {},
+      "ENABLED": {}
+    }
+  },
+  "hobHood": {
+    "hobToHoodFanSpeed": {
+      "access": "readwrite",
+      "type": "string",
+      "values": {
+        "BOOST": {},
+        "BREEZE": {},
+        "OFF": {},
+        "STEP_1": {},
+        "STEP_2": {},
+        "STEP_3": {}
+      }
+    },
+    "hobToHoodMode": {
+      "access": "readwrite",
+      "type": "string",
+      "values": {
+        "H1": {},
+        "H2": {},
+        "H3": {},
+        "H4": {}
+      }
+    },
+    "hobToHoodState": {
+      "access": "readwrite",
+      "type": "string",
+      "values": {
+        "AUTOMATIC": {},
+        "AUTO_SUSPEND": {
+          "disabled": true
+        },
+        "MANUAL": {}
+      }
+    },
+    "hoodFilterCharcIndication": {
+      "access": "readwrite",
+      "type": "boolean",
+      "values": {
+        "FALSE": {},
+        "TRUE": {}
+      }
+    },
+    "targetDuration": {
+      "access": "readwrite",
+      "default": 0,
+      "max": 5940,
+      "min": 0,
+      "step": 60,
+      "type": "number"
+    },
+    "timeToEnd": {
+      "access": "read",
+      "type": "number"
+    },
+    "windowNotification": {
+      "access": "read",
+      "type": "string",
+      "values": {
+        "NONE": {},
+        "OPENING_REQUIRED": {}
+      }
+    }
+  },
+  "hobModule1": {
+    "heatingModuleType": {
+      "access": "read",
+      "type": "number"
+    },
+    "hobFrontZone": {
+      "access": "read",
+      "type": "string"
+    },
+    "hobMiddleZone": {
+      "access": "read",
+      "type": "string"
+    },
+    "hobRearZone": {
+      "access": "read",
+      "type": "string"
+    },
+    "procookLevelFront": {
+      "access": "readwrite",
+      "max": 9,
+      "min": 0,
+      "step": 1,
+      "type": "number"
+    },
+    "procookLevelRear": {
+      "access": "readwrite",
+      "max": 9,
+      "min": 0,
+      "step": 1,
+      "type": "number"
+    }
+  },
+  "hobModule2": {
+    "heatingModuleType": {
+      "access": "read",
+      "type": "number"
+    },
+    "hobFrontZone": {
+      "access": "read",
+      "type": "string"
+    },
+    "hobMiddleZone": {
+      "access": "read",
+      "type": "string"
+    },
+    "hobRearZone": {
+      "access": "read",
+      "type": "string"
+    },
+    "procookLevelFront": {
+      "access": "readwrite",
+      "max": 9,
+      "min": 0,
+      "step": 1,
+      "type": "number"
+    },
+    "procookLevelRear": {
+      "access": "readwrite",
+      "max": 9,
+      "min": 0,
+      "step": 1,
+      "type": "number"
+    }
+  },
+  "hobZone1": {
+    "heatingQualitativeLevel": {
+      "access": "readwrite",
+      "default": 0,
+      "max": 9,
+      "min": 0,
+      "step": 1,
+      "type": "number",
+      "values": {
+        "POWER_LEVEL_P": {}
+      }
+    },
+    "hobCoil": {
+      "access": "read",
+      "type": "number"
+    },
+    "hobMaxPowerLevel": {
+      "access": "read",
+      "type": "number"
+    },
+    "hobPotDetected": {
+      "access": "read",
+      "type": "string",
+      "values": {
+        "NO_POT_IDLE": {},
+        "NO_POT_RUNNING": {},
+        "POT_IDLE": {},
+        "POT_RUNNING": {}
+      }
+    },
+    "reminderTime": {
+      "access": "read",
+      "max": 5940,
+      "min": 0,
+      "step": 60,
+      "triggers": [
+        {
+          "action": {
+            "$self": {
+              "access": "readwrite"
+            }
+          },
+          "condition": {
+            "operand_1": "value",
+            "operand_2": 0,
+            "operator": "eq"
+          }
+        },
+        {
+          "action": {
+            "$self": {
+              "access": "read"
+            }
+          },
+          "condition": {
+            "operand_1": "value",
+            "operand_2": 0,
+            "operator": "ne"
+          }
+        }
+      ],
+      "type": "number"
+    },
+    "residualHeatState": {
+      "access": "read",
+      "type": "string",
+      "values": {
+        "HIGH": {},
+        "LOW": {},
+        "MIDDLE": {},
+        "NO": {}
+      }
+    },
+    "runningTime": {
+      "access": "read",
+      "default": 0,
+      "type": "number"
+    },
+    "targetDuration": {
+      "access": "read",
+      "max": 5940,
+      "min": 0,
+      "step": 60,
+      "triggers": [
+        {
+          "action": {
+            "$self": {
+              "access": "readwrite"
+            }
+          },
+          "condition": {
+            "operand_1": "value",
+            "operand_2": 0,
+            "operator": "eq"
+          }
+        },
+        {
+          "action": {
+            "$self": {
+              "access": "read"
+            }
+          },
+          "condition": {
+            "operand_1": "value",
+            "operand_2": 0,
+            "operator": "ne"
+          }
+        }
+      ],
+      "type": "number"
+    },
+    "timeToEnd": {
+      "access": "read",
+      "type": "number"
+    }
+  },
+  "hobZone2": {
+    "heatingQualitativeLevel": {
+      "access": "read",
+      "default": 0,
+      "max": 9,
+      "min": 0,
+      "step": 1,
+      "type": "number",
+      "values": {
+        "POWER_LEVEL_P": {}
+      }
+    },
+    "hobCoil": {
+      "access": "read",
+      "type": "number"
+    },
+    "hobMaxPowerLevel": {
+      "access": "read",
+      "type": "number"
+    },
+    "hobPotDetected": {
+      "access": "read",
+      "type": "string",
+      "values": {
+        "NO_POT_IDLE": {},
+        "NO_POT_RUNNING": {},
+        "POT_IDLE": {},
+        "POT_RUNNING": {}
+      }
+    },
+    "reminderTime": {
+      "access": "read",
+      "max": 5940,
+      "min": 0,
+      "step": 60,
+      "triggers": [
+        {
+          "action": {
+            "$self": {
+              "access": "readwrite"
+            }
+          },
+          "condition": {
+            "operand_1": "value",
+            "operand_2": 0,
+            "operator": "eq"
+          }
+        },
+        {
+          "action": {
+            "$self": {
+              "access": "read"
+            }
+          },
+          "condition": {
+            "operand_1": "value",
+            "operand_2": 0,
+            "operator": "ne"
+          }
+        }
+      ],
+      "type": "number"
+    },
+    "residualHeatState": {
+      "access": "read",
+      "type": "string",
+      "values": {
+        "HIGH": {},
+        "LOW": {},
+        "MIDDLE": {},
+        "NO": {}
+      }
+    },
+    "runningTime": {
+      "access": "read",
+      "default": 0,
+      "type": "number"
+    },
+    "targetDuration": {
+      "access": "read",
+      "max": 5940,
+      "min": 0,
+      "step": 60,
+      "triggers": [
+        {
+          "action": {
+            "$self": {
+              "access": "readwrite"
+            }
+          },
+          "condition": {
+            "operand_1": "value",
+            "operand_2": 0,
+            "operator": "eq"
+          }
+        },
+        {
+          "action": {
+            "$self": {
+              "access": "read"
+            }
+          },
+          "condition": {
+            "operand_1": "value",
+            "operand_2": 0,
+            "operator": "ne"
+          }
+        }
+      ],
+      "type": "number"
+    },
+    "timeToEnd": {
+      "access": "read",
+      "type": "number"
+    }
+  },
+  "hobZone3": {
+    "heatingQualitativeLevel": {
+      "access": "read",
+      "default": 0,
+      "max": 9,
+      "min": 0,
+      "step": 1,
+      "type": "number",
+      "values": {
+        "POWER_LEVEL_P": {}
+      }
+    },
+    "hobCoil": {
+      "access": "read",
+      "type": "number"
+    },
+    "hobMaxPowerLevel": {
+      "access": "read",
+      "type": "number"
+    },
+    "hobPotDetected": {
+      "access": "read",
+      "type": "string",
+      "values": {
+        "NO_POT_IDLE": {},
+        "NO_POT_RUNNING": {},
+        "POT_IDLE": {},
+        "POT_RUNNING": {}
+      }
+    },
+    "reminderTime": {
+      "access": "read",
+      "max": 5940,
+      "min": 0,
+      "step": 60,
+      "triggers": [
+        {
+          "action": {
+            "$self": {
+              "access": "readwrite"
+            }
+          },
+          "condition": {
+            "operand_1": "value",
+            "operand_2": 0,
+            "operator": "eq"
+          }
+        },
+        {
+          "action": {
+            "$self": {
+              "access": "read"
+            }
+          },
+          "condition": {
+            "operand_1": "value",
+            "operand_2": 0,
+            "operator": "ne"
+          }
+        }
+      ],
+      "type": "number"
+    },
+    "residualHeatState": {
+      "access": "read",
+      "type": "string",
+      "values": {
+        "HIGH": {},
+        "LOW": {},
+        "MIDDLE": {},
+        "NO": {}
+      }
+    },
+    "runningTime": {
+      "access": "read",
+      "default": 0,
+      "type": "number"
+    },
+    "targetDuration": {
+      "access": "readwrite",
+      "max": 5940,
+      "min": 0,
+      "step": 60,
+      "triggers": [
+        {
+          "action": {
+            "$self": {
+              "access": "readwrite"
+            }
+          },
+          "condition": {
+            "operand_1": "value",
+            "operand_2": 0,
+            "operator": "eq"
+          }
+        },
+        {
+          "action": {
+            "$self": {
+              "access": "read"
+            }
+          },
+          "condition": {
+            "operand_1": "value",
+            "operand_2": 0,
+            "operator": "ne"
+          }
+        }
+      ],
+      "type": "number"
+    },
+    "timeToEnd": {
+      "access": "read",
+      "type": "number"
+    }
+  },
+  "hobZone4": {
+    "heatingQualitativeLevel": {
+      "access": "read",
+      "default": 0,
+      "max": 9,
+      "min": 0,
+      "step": 1,
+      "type": "number",
+      "values": {
+        "POWER_LEVEL_P": {}
+      }
+    },
+    "hobCoil": {
+      "access": "read",
+      "type": "number"
+    },
+    "hobMaxPowerLevel": {
+      "access": "read",
+      "type": "number"
+    },
+    "hobPotDetected": {
+      "access": "read",
+      "type": "string",
+      "values": {
+        "NO_POT_IDLE": {},
+        "NO_POT_RUNNING": {},
+        "POT_IDLE": {},
+        "POT_RUNNING": {}
+      }
+    },
+    "reminderTime": {
+      "access": "read",
+      "max": 5940,
+      "min": 0,
+      "step": 60,
+      "triggers": [
+        {
+          "action": {
+            "$self": {
+              "access": "readwrite"
+            }
+          },
+          "condition": {
+            "operand_1": "value",
+            "operand_2": 0,
+            "operator": "eq"
+          }
+        },
+        {
+          "action": {
+            "$self": {
+              "access": "read"
+            }
+          },
+          "condition": {
+            "operand_1": "value",
+            "operand_2": 0,
+            "operator": "ne"
+          }
+        }
+      ],
+      "type": "number"
+    },
+    "residualHeatState": {
+      "access": "read",
+      "type": "string",
+      "values": {
+        "HIGH": {},
+        "LOW": {},
+        "MIDDLE": {},
+        "NO": {}
+      }
+    },
+    "runningTime": {
+      "access": "read",
+      "default": 0,
+      "type": "number"
+    },
+    "targetDuration": {
+      "access": "read",
+      "max": 5940,
+      "min": 0,
+      "step": 60,
+      "triggers": [
+        {
+          "action": {
+            "$self": {
+              "access": "readwrite"
+            }
+          },
+          "condition": {
+            "operand_1": "value",
+            "operand_2": 0,
+            "operator": "eq"
+          }
+        },
+        {
+          "action": {
+            "$self": {
+              "access": "read"
+            }
+          },
+          "condition": {
+            "operand_1": "value",
+            "operand_2": 0,
+            "operator": "ne"
+          }
+        }
+      ],
+      "type": "number"
+    },
+    "timeToEnd": {
+      "access": "read",
+      "type": "number"
+    }
+  },
+  "hobZone7": {
+    "heatingQualitativeLevel": {
+      "access": "read",
+      "default": 0,
+      "max": 9,
+      "min": 0,
+      "step": 1,
+      "type": "number",
+      "values": {
+        "POWER_LEVEL_P": {}
+      }
+    },
+    "hobCoil": {
+      "access": "read",
+      "type": "number"
+    },
+    "hobMaxPowerLevel": {
+      "access": "read",
+      "type": "number"
+    },
+    "hobPotDetected": {
+      "access": "read",
+      "type": "string",
+      "values": {
+        "NO_POT_IDLE": {},
+        "NO_POT_RUNNING": {},
+        "POT_IDLE": {},
+        "POT_RUNNING": {}
+      }
+    },
+    "runningTime": {
+      "access": "read",
+      "default": 0,
+      "type": "number"
+    }
+  },
+  "hobZone8": {
+    "heatingQualitativeLevel": {
+      "access": "read",
+      "default": 0,
+      "max": 9,
+      "min": 0,
+      "step": 1,
+      "type": "number",
+      "values": {
+        "POWER_LEVEL_P": {}
+      }
+    },
+    "hobCoil": {
+      "access": "read",
+      "type": "number"
+    },
+    "hobMaxPowerLevel": {
+      "access": "read",
+      "type": "number"
+    },
+    "hobPotDetected": {
+      "access": "read",
+      "type": "string",
+      "values": {
+        "NO_POT_IDLE": {},
+        "NO_POT_RUNNING": {},
+        "POT_IDLE": {},
+        "POT_RUNNING": {}
+      }
+    },
+    "runningTime": {
+      "access": "read",
+      "default": 0,
+      "type": "number"
+    }
+  },
+  "keyModel": {
+    "access": "constant",
+    "default": "Combo_DoubleFlexiBridge_4Zone_KM201.0.0",
+    "type": "string"
+  },
+  "keySoundTone": {
+    "access": "readwrite",
+    "type": "string",
+    "values": {
+      "CLICK": {},
+      "NONE": {}
+    }
+  },
+  "networkInterface": {
+    "command": {
+      "access": "write",
+      "type": "string",
+      "values": {
+        "APPLIANCE_AUTHORIZE": {},
+        "START": {},
+        "USER_AUTHORIZE": {},
+        "USER_NOT_AUTHORIZE": {}
+      }
+    },
+    "linkQualityIndicator": {
+      "access": "read",
+      "type": "string",
+      "values": {
+        "EXCELLENT": {},
+        "GOOD": {},
+        "POOR": {},
+        "UNDEFINED": {},
+        "VERY_GOOD": {},
+        "VERY_POOR": {}
+      }
+    },
+    "niuSwUpdateCurrentDescription": {
+      "access": "read",
+      "type": "string"
+    },
+    "otaState": {
+      "access": "read",
+      "type": "string",
+      "values": {
+        "DESCRIPTION_AVAILABLE": {},
+        "DESCRIPTION_DOWNLOADING": {},
+        "DESCRIPTION_READY": {},
+        "FW_DOWNLOADING": {},
+        "FW_DOWNLOAD_START": {},
+        "FW_SIGNATURE_CHECK": {},
+        "FW_UPDATE_IN_PROGRESS": {},
+        "IDLE": {},
+        "READY_TO_UPDATE": {},
+        "UPDATE_ABORT": {},
+        "UPDATE_CHECK": {},
+        "UPDATE_ERROR": {},
+        "UPDATE_OK": {},
+        "WAITINGFORAUTHORIZATION": {}
+      }
+    },
+    "startUpCommand": {
+      "access": "write",
+      "type": "string",
+      "values": {
+        "UNINSTALL": {}
+      }
+    },
+    "swAncAndRevision": {
+      "access": "read",
+      "type": "string"
+    },
+    "swVersion": {
+      "access": "read",
+      "type": "string"
+    }
+  },
+  "remoteControl": {
+    "access": "read",
+    "type": "string",
+    "values": {
+      "DISABLED": {},
+      "ENABLED": {},
+      "NOT_SAFETY_RELEVANT_ENABLED": {},
+      "TEMPORARY_LOCKED": {}
+    }
+  },
+  "uiLockMode": {
+    "access": "read",
+    "type": "boolean",
+    "values": {
+      "OFF": {},
+      "ON": {}
+    }
+  }
+}

--- a/samples/CCE84779CB/get_appliance_state.json
+++ b/samples/CCE84779CB/get_appliance_state.json
@@ -1,0 +1,118 @@
+{
+  "applianceData": {
+    "applianceName": "Hob",
+    "created": "2026-08-12T16:33:36.484Z",
+    "modelName": "HB"
+  },
+  "applianceId": "12345678_00:11223344-AABBCCDDEEFF",
+  "connectionState": "connected",
+  "properties": {
+    "desired": {},
+    "metadata": {},
+    "metadataDesired": {},
+    "reported": {
+      "alerts": [],
+      "applianceInfo": {
+        "applianceType": "HB",
+        "capabilityHash": "ecc77014ae687c3c987010215a14b17e47a5ae8136d32dd0a36b46debaf73100"
+      },
+      "applianceMode": "NORMAL",
+      "applianceState": "OFF",
+      "childLock": false,
+      "connectivityState": "connected",
+      "cpv": "00",
+      "hobHood": {
+        "hobToHoodFanSpeed": "OFF",
+        "hobToHoodMode": "H4",
+        "hobToHoodState": "AUTOMATIC",
+        "hoodFilterCharcIndication": false,
+        "targetDuration": 0,
+        "timeToEnd": -1,
+        "windowNotification": "NONE"
+      },
+      "hobModule1": {
+        "bridgeMode": "MODE_2_2",
+        "heatingModuleType": 0,
+        "hobFrontZone": "HZ1",
+        "hobMiddleZone": "000",
+        "hobRearZone": "HZ2",
+        "procookLevelFront": 3,
+        "procookLevelRear": 3
+      },
+      "hobModule2": {
+        "bridgeMode": "MODE_2_2",
+        "heatingModuleType": 0,
+        "hobFrontZone": "HZ3",
+        "hobMiddleZone": "000",
+        "hobRearZone": "HZ4",
+        "procookLevelFront": 9,
+        "procookLevelRear": 3
+      },
+      "hobZone1": {
+        "heatingQualitativeLevel": 0,
+        "hobCoil": {},
+        "hobMaxPowerLevel": 253,
+        "hobPotDetected": "NO_POT_IDLE",
+        "reminderTime": -1,
+        "residualHeatState": "NO",
+        "runningTime": -1,
+        "targetDuration": 0
+      },
+      "hobZone2": {
+        "heatingQualitativeLevel": 0,
+        "hobCoil": {},
+        "hobMaxPowerLevel": 253,
+        "hobPotDetected": "NO_POT_IDLE",
+        "reminderTime": -1,
+        "residualHeatState": "NO",
+        "runningTime": -1,
+        "targetDuration": 0,
+        "timeToEnd": -1
+      },
+      "hobZone3": {
+        "heatingQualitativeLevel": 0,
+        "hobCoil": {},
+        "hobMaxPowerLevel": 253,
+        "hobPotDetected": "NO_POT_IDLE",
+        "reminderTime": -1,
+        "residualHeatState": "NO",
+        "runningTime": -1,
+        "targetDuration": 0
+      },
+      "hobZone4": {
+        "heatingQualitativeLevel": 0,
+        "hobCoil": {},
+        "hobMaxPowerLevel": 253,
+        "hobPotDetected": "NO_POT_IDLE",
+        "reminderTime": -1,
+        "residualHeatState": "NO",
+        "runningTime": -1,
+        "targetDuration": 0,
+        "timeToEnd": -1
+      },
+      "hobZone7": {
+        "heatingQualitativeLevel": 0,
+        "hobCoil": {},
+        "hobMaxPowerLevel": 253,
+        "hobPotDetected": "NO_POT_IDLE"
+      },
+      "hobZone8": {
+        "heatingQualitativeLevel": 0,
+        "hobCoil": {},
+        "hobMaxPowerLevel": 253,
+        "hobPotDetected": "NO_POT_IDLE"
+      },
+      "keySoundTone": "CLICK",
+      "networkInterface": {
+        "linkQualityIndicator": "VERY_GOOD",
+        "niuSwUpdateCurrentDescription": "A16323312A-S00006975A",
+        "otaState": "IDLE",
+        "swAncAndRevision": "S00006975A",
+        "swVersion": "v1.9.2_hacl"
+      },
+      "remoteControl": "NOT_SAFETY_RELEVANT_ENABLED",
+      "uiLockMode": false
+    }
+  },
+  "status": "enabled"
+}

--- a/samples/CCE84779CB/get_appliances_info.json
+++ b/samples/CCE84779CB/get_appliances_info.json
@@ -1,0 +1,17 @@
+[
+  {
+    "brand": "AEG",
+    "colour": "BLACK",
+    "configurationName": null,
+    "deviceType": "BUILT IN HOB",
+    "elc": "00",
+    "market": "EUROPE",
+    "model": "CCE84779CB",
+    "pnc": "12345678",
+    "productArea": "TASTE",
+    "productionReady": null,
+    "project": "HEL-COMBO FLEXI",
+    "status": 1,
+    "variant": "N/A"
+  }
+]

--- a/samples/CCE84779CB/get_appliances_list.json
+++ b/samples/CCE84779CB/get_appliances_list.json
@@ -1,0 +1,120 @@
+[
+  {
+    "applianceData": {
+      "applianceName": "Hob",
+      "created": "2026-08-12T16:33:36.484Z",
+      "modelName": "HB"
+    },
+    "applianceId": "12345678_00:11223344-AABBCCDDEEFF",
+    "connectionState": "connected",
+    "properties": {
+      "desired": {},
+      "metadata": {},
+      "metadataDesired": {},
+      "reported": {
+        "alerts": [],
+        "applianceInfo": {
+          "applianceType": "HB",
+          "capabilityHash": "ecc77014ae687c3c987010215a14b17e47a5ae8136d32dd0a36b46debaf73100"
+        },
+        "applianceMode": "NORMAL",
+        "applianceState": "OFF",
+        "childLock": false,
+        "connectivityState": "connected",
+        "cpv": "00",
+        "hobHood": {
+          "hobToHoodFanSpeed": "OFF",
+          "hobToHoodMode": "H4",
+          "hobToHoodState": "AUTOMATIC",
+          "hoodFilterCharcIndication": false,
+          "targetDuration": 0,
+          "timeToEnd": -1,
+          "windowNotification": "NONE"
+        },
+        "hobModule1": {
+          "bridgeMode": "MODE_2_2",
+          "heatingModuleType": 0,
+          "hobFrontZone": "HZ1",
+          "hobMiddleZone": "000",
+          "hobRearZone": "HZ2",
+          "procookLevelFront": 3,
+          "procookLevelRear": 3
+        },
+        "hobModule2": {
+          "bridgeMode": "MODE_2_2",
+          "heatingModuleType": 0,
+          "hobFrontZone": "HZ3",
+          "hobMiddleZone": "000",
+          "hobRearZone": "HZ4",
+          "procookLevelFront": 9,
+          "procookLevelRear": 3
+        },
+        "hobZone1": {
+          "heatingQualitativeLevel": 0,
+          "hobCoil": {},
+          "hobMaxPowerLevel": 253,
+          "hobPotDetected": "NO_POT_IDLE",
+          "reminderTime": -1,
+          "residualHeatState": "NO",
+          "runningTime": -1,
+          "targetDuration": 0
+        },
+        "hobZone2": {
+          "heatingQualitativeLevel": 0,
+          "hobCoil": {},
+          "hobMaxPowerLevel": 253,
+          "hobPotDetected": "NO_POT_IDLE",
+          "reminderTime": -1,
+          "residualHeatState": "NO",
+          "runningTime": -1,
+          "targetDuration": 0,
+          "timeToEnd": -1
+        },
+        "hobZone3": {
+          "heatingQualitativeLevel": 0,
+          "hobCoil": {},
+          "hobMaxPowerLevel": 253,
+          "hobPotDetected": "NO_POT_IDLE",
+          "reminderTime": -1,
+          "residualHeatState": "NO",
+          "runningTime": -1,
+          "targetDuration": 0
+        },
+        "hobZone4": {
+          "heatingQualitativeLevel": 0,
+          "hobCoil": {},
+          "hobMaxPowerLevel": 253,
+          "hobPotDetected": "NO_POT_IDLE",
+          "reminderTime": -1,
+          "residualHeatState": "NO",
+          "runningTime": -1,
+          "targetDuration": 0,
+          "timeToEnd": -1
+        },
+        "hobZone7": {
+          "heatingQualitativeLevel": 0,
+          "hobCoil": {},
+          "hobMaxPowerLevel": 253,
+          "hobPotDetected": "NO_POT_IDLE"
+        },
+        "hobZone8": {
+          "heatingQualitativeLevel": 0,
+          "hobCoil": {},
+          "hobMaxPowerLevel": 253,
+          "hobPotDetected": "NO_POT_IDLE"
+        },
+        "keySoundTone": "CLICK",
+        "networkInterface": {
+          "linkQualityIndicator": "VERY_GOOD",
+          "niuSwUpdateCurrentDescription": "A16323312A-S00006975A",
+          "otaState": "IDLE",
+          "swAncAndRevision": "S00006975A",
+          "swVersion": "v1.9.2_hacl"
+        },
+        "remoteControl": "NOT_SAFETY_RELEVANT_ENABLED",
+        "uiLockMode": false
+      }
+    },
+    "status": "enabled"
+  }
+]

--- a/testAppliance.py
+++ b/testAppliance.py
@@ -42,21 +42,29 @@ async def main() -> None:
             model_name = (appliance.get("applianceData") or {}).get("modelName", "unknown")
             print(f"== {model_name} {appliance_id}", file=sys.stderr)
 
-            bundle = {"get_appliances_list": appliance}
-            # aid is bound as a default so each lambda captures this
-            # iteration's appliance, not the loop variable.
-            for name, call in (
-                ("get_appliances_info", lambda aid=appliance_id: client.get_appliances_info([aid])),
-                ("get_appliance_state", lambda aid=appliance_id: client.get_appliance_state(aid)),
-                ("get_appliance_capabilities", lambda aid=appliance_id: client.get_appliance_capabilities(aid)),
-            ):
+            async def dump(name, coro):
+                """Await one call, recording the error instead of raising."""
                 try:
-                    bundle[name] = await call()
+                    return await coro
                 except Exception as err:  # noqa: BLE001
                     # Some appliances (robot vacuums for instance) have no
                     # capability document; keep going so the rest is usable.
-                    print(f"   {name}: {type(err).__name__}: {err}", file=sys.stderr)
-                    bundle[name] = {"error": f"{type(err).__name__}: {err}"}
+                    detail = f"{type(err).__name__}: {err}"
+                    print(f"   {name}: {detail}", file=sys.stderr)
+                    return {"error": detail}
+
+            bundle = {
+                "get_appliances_list": appliance,
+                "get_appliances_info": await dump(
+                    "get_appliances_info", client.get_appliances_info([appliance_id])
+                ),
+                "get_appliance_state": await dump(
+                    "get_appliance_state", client.get_appliance_state(appliance_id)
+                ),
+                "get_appliance_capabilities": await dump(
+                    "get_appliance_capabilities", client.get_appliance_capabilities(appliance_id)
+                ),
+            }
 
             if output_dir:
                 # modelName carries the appliance *type* (HB, WM, CR), so it

--- a/testAppliance.py
+++ b/testAppliance.py
@@ -1,33 +1,69 @@
+"""Dump the raw Electrolux API payloads for every appliance on an account.
+
+Useful when adding support for a new appliance: the capability document it
+prints is the source of truth the integration builds entities from.
+
+    ELECTROLUX_USERNAME=you@example.com \
+    ELECTROLUX_PASSWORD=secret \
+    ELECTROLUX_COUNTRY=se \
+    python testAppliance.py [output_directory]
+
+With an output directory, one JSON file per appliance is written there instead
+of everything going to stdout. Payloads contain the appliance id, PNC and
+serial number, so sanitize them before attaching them to an issue or a PR.
+"""
+
 import asyncio
 import json
+import os
+import sys
+
 from pyelectroluxocp import OneAppApi
-import re
 
-# Fill in your username and password here :
-login="xxx"
-password="xxx"
 
-async def main():
-    async with OneAppApi(login, password) as client:
+async def main() -> None:
+    """Fetch and dump list, info, state and capabilities per appliance."""
+    username = os.environ.get("ELECTROLUX_USERNAME")
+    password = os.environ.get("ELECTROLUX_PASSWORD")
+    country = os.environ.get("ELECTROLUX_COUNTRY", "us")
+    if not username or not password:
+        sys.exit("Set ELECTROLUX_USERNAME and ELECTROLUX_PASSWORD")
+
+    output_dir = sys.argv[1] if len(sys.argv) > 1 else None
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+
+    async with OneAppApi(username, password, country) as client:
         appliances = await client.get_appliances_list()
-        print("get_appliances_list :\n",json.dumps(appliances, indent=2))
+        print(f"Found {len(appliances)} appliance(s)", file=sys.stderr)
 
-        info = await client.get_appliance_status(appliances[0].get("applianceId"))
-        json_object = json.dumps(info, indent=2)
-        print("get_appliance_status :\n", json_object)
+        for appliance in appliances:
+            appliance_id = appliance.get("applianceId")
+            model_name = (appliance.get("applianceData") or {}).get("modelName", "unknown")
+            print(f"== {model_name} {appliance_id}", file=sys.stderr)
 
-        info = await client.get_appliance_capabilities(appliances[0].get("applianceId"))
-        json_object = json.dumps(info, indent=2)
-        print("get_appliance_capabilities :\n", json_object)
+            bundle = {"get_appliances_list": appliance}
+            for name, call in (
+                ("get_appliances_info", lambda: client.get_appliances_info([appliance_id])),
+                ("get_appliance_state", lambda: client.get_appliance_state(appliance_id)),
+                ("get_appliance_capabilities", lambda: client.get_appliance_capabilities(appliance_id)),
+            ):
+                try:
+                    bundle[name] = await call()
+                except Exception as err:  # noqa: BLE001
+                    # Some appliances (robot vacuums for instance) have no
+                    # capability document; keep going so the rest is usable.
+                    print(f"   {name}: {type(err).__name__}: {err}", file=sys.stderr)
+                    bundle[name] = {"error": f"{type(err).__name__}: {err}"}
 
-        # Writing to sample.json
-        # with open("results.json", "w") as outfile:
-        #     outfile.write(json_object)
-        #
-        # def state_update_callback(a):
-        #     print("appliance state updated", json.dumps((a)))
-        # await client.watch_for_appliance_state_updates([appliances[0].get("applianceId")], state_update_callback)
+            if output_dir:
+                safe_name = "".join(c if c.isalnum() else "_" for c in str(model_name))
+                path = os.path.join(output_dir, f"{safe_name}.json")
+                with open(path, "w", encoding="utf-8") as handle:
+                    json.dump(bundle, handle, indent=2, sort_keys=True)
+                print(f"   written to {path}", file=sys.stderr)
+            else:
+                print(json.dumps(bundle, indent=2, sort_keys=True))
 
-        #await asyncio.sleep(100)
 
 asyncio.run(main())

--- a/testAppliance.py
+++ b/testAppliance.py
@@ -43,10 +43,12 @@ async def main() -> None:
             print(f"== {model_name} {appliance_id}", file=sys.stderr)
 
             bundle = {"get_appliances_list": appliance}
+            # aid is bound as a default so each lambda captures this
+            # iteration's appliance, not the loop variable.
             for name, call in (
-                ("get_appliances_info", lambda: client.get_appliances_info([appliance_id])),
-                ("get_appliance_state", lambda: client.get_appliance_state(appliance_id)),
-                ("get_appliance_capabilities", lambda: client.get_appliance_capabilities(appliance_id)),
+                ("get_appliances_info", lambda aid=appliance_id: client.get_appliances_info([aid])),
+                ("get_appliance_state", lambda aid=appliance_id: client.get_appliance_state(aid)),
+                ("get_appliance_capabilities", lambda aid=appliance_id: client.get_appliance_capabilities(aid)),
             ):
                 try:
                     bundle[name] = await call()
@@ -57,7 +59,10 @@ async def main() -> None:
                     bundle[name] = {"error": f"{type(err).__name__}: {err}"}
 
             if output_dir:
-                safe_name = "".join(c if c.isalnum() else "_" for c in str(model_name))
+                # modelName carries the appliance *type* (HB, WM, CR), so it
+                # is not unique on an account with two appliances of a kind.
+                # The appliance id is.
+                safe_name = "".join(c if c.isalnum() else "_" for c in f"{model_name}_{appliance_id}")
                 path = os.path.join(output_dir, f"{safe_name}.json")
                 with open(path, "w", encoding="utf-8") as handle:
                     json.dump(bundle, handle, indent=2, sort_keys=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,103 @@
+"""Shared fixtures for the Electrolux Status tests.
+
+The tests build appliances straight from the sanitized sample payloads in
+``samples/`` so that entity generation is exercised against real capability
+documents rather than against hand-written approximations of them.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SAMPLES = REPO_ROOT / "samples"
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from custom_components.electrolux_status.api import (  # noqa: E402
+    Appliance,
+    Appliances,
+    ElectroluxLibraryEntity,
+)
+
+
+def load_sample(model: str, name: str) -> Any:
+    """Return one sanitized sample payload."""
+    return json.loads((SAMPLES / model / f"{name}.json").read_text())
+
+
+class StubConfigEntry:
+    """Minimal stand-in for a Home Assistant config entry."""
+
+    entry_id = "test-entry"
+
+
+class StubCoordinator:
+    """Minimal stand-in for ElectroluxCoordinator.
+
+    ``ElectroluxEntity`` only needs ``api``, ``config_entry`` and ``data``
+    during construction, so the tests avoid pulling in a full Home Assistant
+    instance.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the stub."""
+        self.api = None
+        self.config_entry = StubConfigEntry()
+        self.data: dict[str, Any] = {}
+
+
+def build_appliance(model: str) -> Appliance:
+    """Build and set up an Appliance from the sanitized samples for a model."""
+    state = load_sample(model, "get_appliance_state")
+    info = load_sample(model, "get_appliances_info")[0]
+    capabilities = load_sample(model, "get_appliance_capabilities")
+    appliance_id = state["applianceId"]
+
+    coordinator = StubCoordinator()
+    appliance = Appliance(
+        coordinator=coordinator,
+        name=state["applianceData"]["applianceName"],
+        pnc_id=appliance_id,
+        brand=info["brand"],
+        model=info["model"],
+        state=state,
+    )
+    coordinator.data["appliances"] = Appliances({appliance_id: appliance})
+    appliance.setup(
+        ElectroluxLibraryEntity(
+            name=appliance.name,
+            status=state.get("connectionState"),
+            state=state,
+            appliance_info=info,
+            capabilities=capabilities,
+        )
+    )
+    # The coordinator pushes the first status right after setup; without it the
+    # entities have no appliance status to read values from.
+    appliance.update(state)
+    return appliance
+
+
+@pytest.fixture
+def hob() -> Appliance:
+    """Return the AEG CCE84779CB induction hob (applianceType HB)."""
+    return build_appliance("CCE84779CB")
+
+
+@pytest.fixture
+def fridge() -> Appliance:
+    """Return a non-HB appliance, used to check for regressions."""
+    return build_appliance("EHE6899SA")
+
+
+@pytest.fixture
+def washer() -> Appliance:
+    """Return a non-HB appliance, used to check for regressions."""
+    return build_appliance("EW7F3816DB")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,18 @@ def build_appliance(model: str) -> Appliance:
     return appliance
 
 
+def entity_by_path(appliance: Appliance, path: str):
+    """Return the single entity generated for a capability path."""
+    matches = [entity for entity in appliance.entities if entity.json_path == path]
+    assert len(matches) == 1, f"expected exactly one entity for {path}, got {len(matches)}"
+    return matches[0]
+
+
+def paths(appliance: Appliance) -> set[str]:
+    """Return every capability path the appliance generated an entity for."""
+    return {entity.json_path for entity in appliance.entities}
+
+
 @pytest.fixture
 def hob() -> Appliance:
     """Return the AEG CCE84779CB induction hob (applianceType HB)."""

--- a/tests/test_hob.py
+++ b/tests/test_hob.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
@@ -159,15 +161,51 @@ def test_hood_state_options_come_from_capabilities(hob) -> None:
 
 
 def test_disabled_enum_values_are_not_selectable(hob) -> None:
-    """AUTO_SUSPEND is marked disabled, so it must not be offered.
-
-    The appliance still reports the state, so it stays displayable; it just
-    may not be chosen.
-    """
+    """AUTO_SUSPEND is marked disabled, so it must not be offered."""
     hood_state = entity_by_path(hob, "hobHood/hobToHoodState")
     assert "Auto Suspend" in hood_state.readonly_options
     assert "Auto Suspend" not in hood_state.options
     assert sorted(hood_state.options) == ["Automatic", "Manual"]
+
+
+def test_disabled_value_stays_visible_while_reported(hob) -> None:
+    """A disabled value the appliance reports must not read as unknown.
+
+    Home Assistant drops the state of a select whose current option is not in
+    its option list, so the reported value has to stay in the list while it is
+    current - but it must never become settable.
+    """
+    hood_state = entity_by_path(hob, "hobHood/hobToHoodState")
+    hob.update_reported_data({"hobHood": {"hobToHoodState": "AUTO_SUSPEND"}})
+
+    assert hood_state.current_option == "Auto Suspend"
+    assert "Auto Suspend" in hood_state.options, "state would render as unknown"
+    assert "Auto Suspend" in hood_state.readonly_options
+
+    hob.update_reported_data({"hobHood": {"hobToHoodState": "AUTOMATIC"}})
+    assert hood_state.current_option == "Automatic"
+    assert "Auto Suspend" not in hood_state.options
+
+
+def test_disabled_value_cannot_be_sent(hob) -> None:
+    """Selecting a disabled value never reaches the appliance."""
+    hood_state = entity_by_path(hob, "hobHood/hobToHoodState")
+    hob.update_reported_data({"hobHood": {"hobToHoodState": "AUTO_SUSPEND"}})
+    assert "Auto Suspend" in hood_state.options
+
+    sent = []
+
+    class RecordingApi:
+        async def execute_appliance_command(self, *args):
+            sent.append(args)
+
+    hood_state.api = RecordingApi()
+
+    asyncio.run(hood_state.async_select_option("Auto Suspend"))
+    assert sent == []
+
+    asyncio.run(hood_state.async_select_option("Manual"))
+    assert sent == [(hob.pnc_id, {"hobHood": {"hobToHoodState": "MANUAL"}})]
 
 
 def test_number_bounds_come_from_capabilities(hob) -> None:

--- a/tests/test_hob.py
+++ b/tests/test_hob.py
@@ -248,6 +248,34 @@ def test_undocumented_reported_value_stays_selectable(hob) -> None:
     assert "Drying Cycle" not in fan_speed.readonly_options
 
 
+def test_zero_is_a_value_not_a_missing_reading(hob) -> None:
+    """A number reporting 0 renders 0, not unknown.
+
+    The extractor run-on duration reports 0 and declares a default of 0, which
+    used to fall through to an empty cache and leave the entity unknown.
+    """
+    duration = entity_by_path(hob, "hobHood/targetDuration")
+    assert duration.capability["default"] == 0
+    assert hob.get_state("hobHood/targetDuration") == 0
+    assert duration.native_value == 0
+
+
+def test_duration_number_is_presented_in_minutes(hob) -> None:
+    """Seconds-based numbers are scaled to whole minutes, both ways.
+
+    ElectroluxNumber converts a seconds unit to minutes for display and back
+    for writing, so declaring the unit changes the control's scale.
+    """
+    duration = entity_by_path(hob, "hobHood/targetDuration")
+    assert duration.native_unit_of_measurement == UnitOfTime.MINUTES
+    assert duration.native_min_value == 0
+    assert duration.native_max_value == 99
+    assert duration.native_step == 1
+
+    hob.update_reported_data({"hobHood": {"targetDuration": 3600}})
+    assert duration.native_value == 60
+
+
 def test_number_bounds_come_from_capabilities(hob) -> None:
     """Numeric bounds are taken from the capability document."""
     duration = entity_by_path(hob, "hobHood/targetDuration")

--- a/tests/test_hob.py
+++ b/tests/test_hob.py
@@ -195,6 +195,24 @@ def test_disabled_value_stays_visible_while_reported(hob) -> None:
     assert "Auto Suspend" not in hood_state.options
 
 
+def test_disabled_value_survives_a_payload_that_omits_it(hob) -> None:
+    """A disabled value must stay visible across a partial update.
+
+    Pushes carry only what changed, so an update can omit the whole container.
+    current_option then falls back to the last known label; if options stopped
+    listing that label, HA would render the entity as unknown.
+    """
+    hood_state = entity_by_path(hob, "hobHood/hobToHoodState")
+    hob.update_reported_data({"hobHood": {"hobToHoodState": "AUTO_SUSPEND"}})
+    assert hood_state.current_option == "Auto Suspend"
+
+    # An update that says nothing about the hood at all.
+    hob.reported_state.pop("hobHood")
+
+    assert hood_state.current_option == "Auto Suspend"
+    assert "Auto Suspend" in hood_state.options, "HA would render this as unknown"
+
+
 def test_disabled_value_cannot_be_sent(hob) -> None:
     """Selecting a disabled value is refused loudly, not silently dropped."""
     hood_state = entity_by_path(hob, "hobHood/hobToHoodState")

--- a/tests/test_hob.py
+++ b/tests/test_hob.py
@@ -9,6 +9,7 @@ import pytest
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import Platform, UnitOfTime
+from homeassistant.exceptions import ServiceValidationError
 
 from custom_components.electrolux_status.api import catalog_wildcard_key
 from custom_components.electrolux_status.catalog_core import CATALOG_APPLIANCE_TYPE
@@ -123,7 +124,30 @@ def test_wildcard_catalog_entry_applies_to_every_zone(hob) -> None:
         entity = entity_by_path(hob, f"{zone}/runningTime")
         assert entity.device_class is SensorDeviceClass.DURATION
         assert entity.unit == UnitOfTime.SECONDS
-        assert entity.name == "Running time"
+
+
+def test_wildcard_names_carry_the_container_index(hob) -> None:
+    """A wildcard entry must not give every container the same name.
+
+    has_entity_name composes the device name with this one, so six zones all
+    called "Running time" are indistinguishable in the UI, in search and to
+    voice assistants.
+    """
+    assert entity_by_path(hob, "hobZone1/runningTime").name == "Zone 1 running time"
+    assert entity_by_path(hob, "hobZone7/runningTime").name == "Zone 7 running time"
+    assert entity_by_path(hob, "hobModule2/hobFrontZone").name == "Module 2 front zone"
+
+
+def test_entity_names_are_unique(hob) -> None:
+    """No two entities on the appliance present the same name."""
+    names = [entity.name for entity in hob.entities]
+    duplicates = {name for name in names if names.count(name) > 1}
+    assert not duplicates
+
+
+def test_index_placeholder_does_not_leak(hob) -> None:
+    """Every wildcard name is resolved, never shown raw."""
+    assert not [entity for entity in hob.entities if "{index}" in (entity.name or "")]
 
 
 def test_wildcard_keys_do_not_become_entities(hob) -> None:
@@ -188,7 +212,7 @@ def test_disabled_value_stays_visible_while_reported(hob) -> None:
 
 
 def test_disabled_value_cannot_be_sent(hob) -> None:
-    """Selecting a disabled value never reaches the appliance."""
+    """Selecting a disabled value is refused loudly, not silently dropped."""
     hood_state = entity_by_path(hob, "hobHood/hobToHoodState")
     hob.update_reported_data({"hobHood": {"hobToHoodState": "AUTO_SUSPEND"}})
     assert "Auto Suspend" in hood_state.options
@@ -201,11 +225,27 @@ def test_disabled_value_cannot_be_sent(hob) -> None:
 
     hood_state.api = RecordingApi()
 
-    asyncio.run(hood_state.async_select_option("Auto Suspend"))
+    with pytest.raises(ServiceValidationError):
+        asyncio.run(hood_state.async_select_option("Auto Suspend"))
     assert sent == []
 
     asyncio.run(hood_state.async_select_option("Manual"))
     assert sent == [(hob.pnc_id, {"hobHood": {"hobToHoodState": "MANUAL"}})]
+
+
+def test_undocumented_reported_value_stays_selectable(hob) -> None:
+    """A value missing from the capability document is learned, not withheld.
+
+    Electrolux capability documents are known to omit values appliances
+    really report; withholding them would remove the user's ability to set a
+    value that was working before.
+    """
+    fan_speed = entity_by_path(hob, "hobHood/hobToHoodFanSpeed")
+    hob.update_reported_data({"hobHood": {"hobToHoodFanSpeed": "DRYING_CYCLE"}})
+
+    assert fan_speed.current_option == "Drying Cycle"
+    assert "Drying Cycle" in fan_speed.options
+    assert "Drying Cycle" not in fan_speed.readonly_options
 
 
 def test_number_bounds_come_from_capabilities(hob) -> None:

--- a/tests/test_hob.py
+++ b/tests/test_hob.py
@@ -1,0 +1,320 @@
+"""Tests for HB (hob) appliance support, using the AEG CCE84779CB samples."""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import Platform, UnitOfTime
+
+from custom_components.electrolux_status.api import catalog_wildcard_key
+from custom_components.electrolux_status.catalog_core import CATALOG_APPLIANCE_TYPE
+
+
+def entity_by_path(appliance, path: str):
+    """Return the single entity generated for a capability path."""
+    matches = [entity for entity in appliance.entities if entity.json_path == path]
+    assert len(matches) == 1, f"expected exactly one entity for {path}, got {len(matches)}"
+    return matches[0]
+
+
+def paths(appliance) -> set[str]:
+    """Return every capability path the appliance generated an entity for."""
+    return {entity.json_path for entity in appliance.entities}
+
+
+# --- appliance detection ------------------------------------------------
+
+
+def test_hob_reports_appliance_type_hb(hob) -> None:
+    """The hob is identified by appliance type, not by model name."""
+    assert hob.appliance_type == "HB"
+    assert hob.model == "CCE84779CB"
+    assert hob.brand == "AEG"
+
+
+def test_hob_initializes_and_creates_entities(hob) -> None:
+    """Setting up a CCE84779CB raises nothing and produces entities."""
+    assert len(hob.entities) > 20
+
+
+def test_hob_catalog_layers_appliance_type_over_base(hob) -> None:
+    """The HB catalog is merged in on top of the base catalog."""
+    catalog = hob.catalog
+    # Contributed by CATALOG_BASE.
+    assert "alerts" in catalog
+    # Contributed by CATALOG_APPLIANCE_TYPE["HB"].
+    assert "hobZone*/residualHeatState" in catalog
+    # The HB entry wins over the base entry for the same key.
+    assert catalog["uiLockMode"] is CATALOG_APPLIANCE_TYPE["HB"]["uiLockMode"]
+
+
+# --- nested and dynamic capability discovery ----------------------------
+
+
+def test_nested_hood_capabilities_are_discovered(hob) -> None:
+    """Every hobHood/* capability becomes an entity."""
+    hood_paths = {path for path in paths(hob) if path.startswith("hobHood/")}
+    assert hood_paths == {
+        "hobHood/hobToHoodFanSpeed",
+        "hobHood/hobToHoodMode",
+        "hobHood/hobToHoodState",
+        "hobHood/hoodFilterCharcIndication",
+        "hobHood/targetDuration",
+        "hobHood/timeToEnd",
+        "hobHood/windowNotification",
+    }
+
+
+def test_hob_zones_are_discovered_dynamically(hob) -> None:
+    """Zones come from the capability document, not from a fixed list.
+
+    The CCE84779CB reports a non-contiguous set of zones: 1-4 are the physical
+    zones and 7-8 are the bridged ones, with no zone 5 or 6.
+    """
+    zones = sorted({path.split("/")[0] for path in paths(hob) if path.startswith("hobZone")})
+    assert zones == [
+        "hobZone1",
+        "hobZone2",
+        "hobZone3",
+        "hobZone4",
+        "hobZone7",
+        "hobZone8",
+    ]
+
+
+def test_no_fixed_zone_count_assumption(hob) -> None:
+    """Zones with fewer capabilities produce fewer entities, not errors.
+
+    hobZone7/8 are bridge zones and report five properties where hobZone1-4
+    report nine. Nothing may assume every zone looks the same.
+    """
+    def attributes(zone: str) -> set[str]:
+        return {path.split("/", 1)[1] for path in paths(hob) if path.startswith(f"{zone}/")}
+
+    assert attributes("hobZone7") < attributes("hobZone1")
+    assert "residualHeatState" in attributes("hobZone1")
+    assert "residualHeatState" not in attributes("hobZone7")
+
+
+@pytest.mark.parametrize(
+    ("capability", "expected"),
+    [
+        ("hobZone1/runningTime", "hobZone*/runningTime"),
+        ("hobZone12/runningTime", "hobZone*/runningTime"),
+        ("hobModule2/procookLevelRear", "hobModule*/procookLevelRear"),
+        # No numeric container suffix, so no wildcard form.
+        ("userSelections/analogTemperature", None),
+        ("applianceState", None),
+        ("fCMiscellaneousState/tankAReserve", None),
+    ],
+)
+def test_catalog_wildcard_key(capability: str, expected: str | None) -> None:
+    """Wildcard keys are derived only from a numbered container prefix."""
+    assert catalog_wildcard_key(capability) == expected
+
+
+def test_wildcard_catalog_entry_applies_to_every_zone(hob) -> None:
+    """One catalog entry describes all zones, whatever they are numbered."""
+    for zone in ("hobZone1", "hobZone2", "hobZone3", "hobZone4", "hobZone7", "hobZone8"):
+        entity = entity_by_path(hob, f"{zone}/runningTime")
+        assert entity.device_class is SensorDeviceClass.DURATION
+        assert entity.unit == UnitOfTime.SECONDS
+        assert entity.name == "Running time"
+
+
+def test_wildcard_keys_do_not_become_entities(hob) -> None:
+    """Catalog patterns are never mistaken for real capabilities."""
+    assert not [path for path in paths(hob) if "*" in path]
+
+
+# --- values come from the device, not from guesses ----------------------
+
+
+def test_fan_speed_options_come_from_capabilities(hob) -> None:
+    """The CCE84779CB advertises six fan speeds and no drying cycle."""
+    fan_speed = entity_by_path(hob, "hobHood/hobToHoodFanSpeed")
+    assert fan_speed.entity_type == Platform.SELECT
+    assert sorted(fan_speed.options_list.values()) == [
+        "BOOST",
+        "BREEZE",
+        "OFF",
+        "STEP_1",
+        "STEP_2",
+        "STEP_3",
+    ]
+    assert "DRYING_CYCLE" not in fan_speed.options_list.values()
+
+
+def test_hood_state_options_come_from_capabilities(hob) -> None:
+    """Hood state options are read from the device."""
+    hood_state = entity_by_path(hob, "hobHood/hobToHoodState")
+    assert hood_state.entity_type == Platform.SELECT
+    assert sorted(hood_state.options_list.values()) == [
+        "AUTOMATIC",
+        "AUTO_SUSPEND",
+        "MANUAL",
+    ]
+
+
+def test_disabled_enum_values_are_not_selectable(hob) -> None:
+    """AUTO_SUSPEND is marked disabled, so it must not be offered.
+
+    The appliance still reports the state, so it stays displayable; it just
+    may not be chosen.
+    """
+    hood_state = entity_by_path(hob, "hobHood/hobToHoodState")
+    assert "Auto Suspend" in hood_state.readonly_options
+    assert "Auto Suspend" not in hood_state.options
+    assert sorted(hood_state.options) == ["Automatic", "Manual"]
+
+
+def test_number_bounds_come_from_capabilities(hob) -> None:
+    """Numeric bounds are taken from the capability document."""
+    duration = entity_by_path(hob, "hobHood/targetDuration")
+    assert duration.entity_type == Platform.NUMBER
+    assert duration.capability["min"] == 0
+    assert duration.capability["max"] == 5940
+    assert duration.capability["step"] == 60
+
+
+# --- read-only capabilities stay read-only ------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        # Reported as readwrite by the appliance but pinned read-only: these
+        # are cooking controls, see the note in catalog_hob.py.
+        "hobZone1/heatingQualitativeLevel",
+        "hobZone3/targetDuration",
+        "hobModule1/procookLevelFront",
+        "hobModule2/procookLevelRear",
+        # Reported as read-only, and must not be promoted by the base catalog.
+        "hobZone2/heatingQualitativeLevel",
+        "hobZone4/targetDuration",
+    ],
+)
+def test_cooking_controls_are_read_only(hob, path: str) -> None:
+    """No hob capability is exposed as a writable cooking control."""
+    assert entity_by_path(hob, path).entity_type == Platform.SENSOR
+
+
+def test_writable_capabilities_are_limited_to_the_extractor(hob) -> None:
+    """Only extractor and appliance-settings capabilities are writable."""
+    writable = {
+        entity.json_path
+        for entity in hob.entities
+        if entity.entity_type in (Platform.SELECT, Platform.NUMBER, Platform.SWITCH)
+    }
+    assert writable == {
+        "hobHood/hobToHoodFanSpeed",
+        "hobHood/hobToHoodMode",
+        "hobHood/hobToHoodState",
+        "hobHood/targetDuration",
+        "keySoundTone",
+    }
+
+
+def test_ui_lock_mode_is_read_only_binary_sensor(hob) -> None:
+    """UiLockMode is access "read" on HB and must not become a switch."""
+    ui_lock = entity_by_path(hob, "uiLockMode")
+    assert ui_lock.entity_type == Platform.BINARY_SENSOR
+    assert ui_lock.device_class is BinarySensorDeviceClass.LOCK
+
+
+# --- child lock ---------------------------------------------------------
+
+
+def test_child_lock_has_no_remote_disable_action(hob) -> None:
+    """Child lock is state-only.
+
+    The capability document marks it readwrite but attaches triggers that drop
+    it to read-only once it is enabled, so the appliance cannot honour a remote
+    disable. Exposing a switch would offer an action that silently fails.
+    """
+    child_lock = entity_by_path(hob, "childLock")
+    assert child_lock.entity_type == Platform.BINARY_SENSOR
+    assert child_lock.device_class is BinarySensorDeviceClass.LOCK
+    assert not hasattr(child_lock, "async_turn_off")
+
+
+def test_child_lock_capability_declares_conditional_access(hob) -> None:
+    """Guard the assumption the child lock modelling rests on."""
+    capability = hob.data.get_capability("childLock")
+    conditions = [trigger["condition"]["operand_2"] for trigger in capability["triggers"]]
+    assert "ENABLED" in conditions
+    enabled_trigger = next(
+        trigger for trigger in capability["triggers"] if trigger["condition"]["operand_2"] == "ENABLED"
+    )
+    assert enabled_trigger["action"]["$self"]["access"] == "read"
+
+
+# --- presentation -------------------------------------------------------
+
+
+def test_durations_have_device_class_and_unit(hob) -> None:
+    """Every hob duration is a proper duration sensor."""
+    for path in (
+        "hobHood/timeToEnd",
+        "hobZone1/runningTime",
+        "hobZone1/timeToEnd",
+        "hobZone2/targetDuration",
+        "hobZone4/reminderTime",
+    ):
+        entity = entity_by_path(hob, path)
+        assert entity.device_class is SensorDeviceClass.DURATION, path
+        assert entity.unit == UnitOfTime.SECONDS, path
+
+
+def test_filter_indication_is_a_problem_binary_sensor(hob) -> None:
+    """The charcoal filter indication is a state, not a control."""
+    charcoal = entity_by_path(hob, "hobHood/hoodFilterCharcIndication")
+    assert charcoal.entity_type == Platform.BINARY_SENSOR
+    assert charcoal.device_class is BinarySensorDeviceClass.PROBLEM
+
+
+def test_pot_detection_keeps_all_four_states(hob) -> None:
+    """Pot detection stays an enum so idle/running is not thrown away."""
+    pot = entity_by_path(hob, "hobZone1/hobPotDetected")
+    assert pot.entity_type == Platform.SENSOR
+    assert sorted(pot.capability["values"]) == [
+        "NO_POT_IDLE",
+        "NO_POT_RUNNING",
+        "POT_IDLE",
+        "POT_RUNNING",
+    ]
+
+
+# --- push updates -------------------------------------------------------
+
+
+def test_push_update_changes_state_without_recreating_entities(hob) -> None:
+    """A pushed delta updates entity values in place."""
+    before = list(hob.entities)
+    fan_speed = entity_by_path(hob, "hobHood/hobToHoodFanSpeed")
+    level = entity_by_path(hob, "hobZone1/heatingQualitativeLevel")
+    assert fan_speed.current_option == "Off"
+    assert level.native_value == 0
+
+    hob.update_reported_data(
+        {
+            "applianceState": "RUNNING",
+            "hobHood": {"hobToHoodFanSpeed": "STEP_3"},
+            "hobZone1": {"heatingQualitativeLevel": 7, "hobPotDetected": "POT_RUNNING"},
+        }
+    )
+
+    assert hob.entities == before
+    assert fan_speed.current_option == "Step 3"
+    assert level.native_value == 7
+    assert entity_by_path(hob, "hobZone1/hobPotDetected").native_value == "Pot Running"
+    assert entity_by_path(hob, "applianceState").native_value == "Running"
+
+
+def test_push_update_leaves_other_zones_untouched(hob) -> None:
+    """A delta for one zone does not disturb the others."""
+    hob.update_reported_data({"hobZone1": {"heatingQualitativeLevel": 9}})
+    assert entity_by_path(hob, "hobZone1/heatingQualitativeLevel").native_value == 9
+    assert entity_by_path(hob, "hobZone2/heatingQualitativeLevel").native_value == 0

--- a/tests/test_hob.py
+++ b/tests/test_hob.py
@@ -11,20 +11,10 @@ from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import Platform, UnitOfTime
 from homeassistant.exceptions import ServiceValidationError
 
+from conftest import entity_by_path, paths
+
 from custom_components.electrolux_status.api import catalog_wildcard_key
 from custom_components.electrolux_status.catalog_core import CATALOG_APPLIANCE_TYPE
-
-
-def entity_by_path(appliance, path: str):
-    """Return the single entity generated for a capability path."""
-    matches = [entity for entity in appliance.entities if entity.json_path == path]
-    assert len(matches) == 1, f"expected exactly one entity for {path}, got {len(matches)}"
-    return matches[0]
-
-
-def paths(appliance) -> set[str]:
-    """Return every capability path the appliance generated an entity for."""
-    return {entity.json_path for entity in appliance.entities}
 
 
 # --- appliance detection ------------------------------------------------
@@ -104,16 +94,16 @@ def test_no_fixed_zone_count_assumption(hob) -> None:
 @pytest.mark.parametrize(
     ("capability", "expected"),
     [
-        ("hobZone1/runningTime", "hobZone*/runningTime"),
-        ("hobZone12/runningTime", "hobZone*/runningTime"),
-        ("hobModule2/procookLevelRear", "hobModule*/procookLevelRear"),
+        ("hobZone1/runningTime", ("hobZone*/runningTime", "1")),
+        ("hobZone12/runningTime", ("hobZone*/runningTime", "12")),
+        ("hobModule2/procookLevelRear", ("hobModule*/procookLevelRear", "2")),
         # No numeric container suffix, so no wildcard form.
         ("userSelections/analogTemperature", None),
         ("applianceState", None),
         ("fCMiscellaneousState/tankAReserve", None),
     ],
 )
-def test_catalog_wildcard_key(capability: str, expected: str | None) -> None:
+def test_catalog_wildcard_key(capability: str, expected: tuple[str, str] | None) -> None:
     """Wildcard keys are derived only from a numbered container prefix."""
     assert catalog_wildcard_key(capability) == expected
 
@@ -158,30 +148,24 @@ def test_wildcard_keys_do_not_become_entities(hob) -> None:
 # --- values come from the device, not from guesses ----------------------
 
 
-def test_fan_speed_options_come_from_capabilities(hob) -> None:
-    """The CCE84779CB advertises six fan speeds and no drying cycle."""
-    fan_speed = entity_by_path(hob, "hobHood/hobToHoodFanSpeed")
-    assert fan_speed.entity_type == Platform.SELECT
-    assert sorted(fan_speed.options_list.values()) == [
-        "BOOST",
-        "BREEZE",
-        "OFF",
-        "STEP_1",
-        "STEP_2",
-        "STEP_3",
-    ]
-    assert "DRYING_CYCLE" not in fan_speed.options_list.values()
-
-
-def test_hood_state_options_come_from_capabilities(hob) -> None:
-    """Hood state options are read from the device."""
-    hood_state = entity_by_path(hob, "hobHood/hobToHoodState")
-    assert hood_state.entity_type == Platform.SELECT
-    assert sorted(hood_state.options_list.values()) == [
-        "AUTOMATIC",
-        "AUTO_SUSPEND",
-        "MANUAL",
-    ]
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        # Note the absence of DRYING_CYCLE, which the upstream peacock_hob
+        # fixture has and this model does not.
+        (
+            "hobHood/hobToHoodFanSpeed",
+            ["BOOST", "BREEZE", "OFF", "STEP_1", "STEP_2", "STEP_3"],
+        ),
+        ("hobHood/hobToHoodState", ["AUTOMATIC", "AUTO_SUSPEND", "MANUAL"]),
+        ("keySoundTone", ["CLICK", "NONE"]),
+    ],
+)
+def test_select_values_come_from_capabilities(hob, path: str, expected: list[str]) -> None:
+    """Selectable values are read from the device, never guessed."""
+    entity = entity_by_path(hob, path)
+    assert entity.entity_type == Platform.SELECT
+    assert sorted(entity.options_list.values()) == expected
 
 
 def test_disabled_enum_values_are_not_selectable(hob) -> None:
@@ -267,6 +251,7 @@ def test_duration_number_is_presented_in_minutes(hob) -> None:
     for writing, so declaring the unit changes the control's scale.
     """
     duration = entity_by_path(hob, "hobHood/targetDuration")
+    assert duration.entity_type == Platform.NUMBER
     assert duration.native_unit_of_measurement == UnitOfTime.MINUTES
     assert duration.native_min_value == 0
     assert duration.native_max_value == 99
@@ -274,15 +259,6 @@ def test_duration_number_is_presented_in_minutes(hob) -> None:
 
     hob.update_reported_data({"hobHood": {"targetDuration": 3600}})
     assert duration.native_value == 60
-
-
-def test_number_bounds_come_from_capabilities(hob) -> None:
-    """Numeric bounds are taken from the capability document."""
-    duration = entity_by_path(hob, "hobHood/targetDuration")
-    assert duration.entity_type == Platform.NUMBER
-    assert duration.capability["min"] == 0
-    assert duration.capability["max"] == 5940
-    assert duration.capability["step"] == 60
 
 
 # --- read-only capabilities stay read-only ------------------------------

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -4,12 +4,9 @@ from __future__ import annotations
 
 from homeassistant.const import Platform
 
+from conftest import entity_by_path, paths
+
 from custom_components.electrolux_status.catalog_core import CATALOG_BASE, CATALOG_MODEL
-
-
-def paths(appliance) -> set[str]:
-    """Return every capability path the appliance generated an entity for."""
-    return {entity.json_path for entity in appliance.entities}
 
 
 def test_fridge_still_sets_up(fridge) -> None:
@@ -39,8 +36,7 @@ def test_model_overrides_still_apply(fridge) -> None:
 
 def test_non_hb_ui_lock_mode_stays_a_switch(washer) -> None:
     """The HB read-only override must not leak to other appliance types."""
-    ui_lock = next(entity for entity in washer.entities if entity.json_path == "uiLockMode")
-    assert ui_lock.entity_type == Platform.SWITCH
+    assert entity_by_path(washer, "uiLockMode").entity_type == Platform.SWITCH
 
 
 def test_no_hob_entities_on_other_appliances(fridge, washer) -> None:

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -61,3 +61,40 @@ def test_static_attributes_do_not_duplicate_capabilities(fridge, washer, hob) ->
     for appliance in (fridge, washer, hob):
         unique_ids = [entity.unique_id for entity in appliance.entities]
         assert len(unique_ids) == len(set(unique_ids))
+
+
+def test_unclassifiable_capability_still_yields_a_static_entity(fridge) -> None:
+    """A static attribute is kept when the capability pass produces nothing.
+
+    sources_list only requires access+type, but get_entity_type cannot classify
+    every such shape. Skipping a static attribute merely because the name
+    appears in the capability document would drop the entity entirely.
+    """
+    from custom_components.electrolux_status.api import Appliance, Appliances, ElectroluxLibraryEntity
+
+    data = fridge.data
+    # A well-formed-looking capability the walker cannot classify.
+    data.capabilities["applianceMode"] = {"access": "readwrite", "type": "string"}
+
+    rebuilt = Appliance(
+        coordinator=fridge.coordinator,
+        name=fridge.name,
+        pnc_id=fridge.pnc_id,
+        brand=fridge.brand,
+        model=fridge.model,
+        state=fridge.state,
+    )
+    fridge.coordinator.data["appliances"] = Appliances({fridge.pnc_id: rebuilt})
+    rebuilt.setup(
+        ElectroluxLibraryEntity(
+            name=data.name,
+            status=data.status,
+            state=fridge.state,
+            appliance_info=data.appliance_info,
+            capabilities=data.capabilities,
+        )
+    )
+
+    assert "applianceMode" in paths(rebuilt)
+    unique_ids = [entity.unique_id for entity in rebuilt.entities]
+    assert len(unique_ids) == len(set(unique_ids))

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,0 +1,67 @@
+"""Checks that non-HB appliances are unaffected by hob support."""
+
+from __future__ import annotations
+
+from homeassistant.const import Platform
+
+from custom_components.electrolux_status.catalog_core import CATALOG_BASE, CATALOG_MODEL
+
+
+def paths(appliance) -> set[str]:
+    """Return every capability path the appliance generated an entity for."""
+    return {entity.json_path for entity in appliance.entities}
+
+
+def test_fridge_still_sets_up(fridge) -> None:
+    """A CR appliance is unchanged by the HB catalog."""
+    assert fridge.appliance_type == "CR"
+    assert len(fridge.entities) > 10
+
+
+def test_washer_still_sets_up(washer) -> None:
+    """A WM appliance is unchanged by the HB catalog."""
+    assert washer.appliance_type == "WM"
+    assert len(washer.entities) > 10
+
+
+def test_appliance_without_overrides_uses_the_base_catalog(washer) -> None:
+    """No appliance-type or model override matches, so nothing is merged."""
+    assert washer.catalog is CATALOG_BASE
+
+
+def test_model_overrides_still_apply(fridge) -> None:
+    """EHE6899SA keeps its model-level overrides alongside the base catalog."""
+    catalog = fridge.catalog
+    assert catalog is not CATALOG_BASE
+    assert catalog["ui2LockMode"] is CATALOG_MODEL["EHE6899SA"]["ui2LockMode"]
+    assert "hobZone*/residualHeatState" not in catalog
+
+
+def test_non_hb_ui_lock_mode_stays_a_switch(washer) -> None:
+    """The HB read-only override must not leak to other appliance types."""
+    ui_lock = next(entity for entity in washer.entities if entity.json_path == "uiLockMode")
+    assert ui_lock.entity_type == Platform.SWITCH
+
+
+def test_no_hob_entities_on_other_appliances(fridge, washer) -> None:
+    """Hob catalog entries never invent entities elsewhere."""
+    for appliance in (fridge, washer):
+        assert not [path for path in paths(appliance) if path.startswith(("hobZone", "hobHood", "hobModule"))]
+
+
+def test_wildcard_entries_never_materialise(fridge, washer) -> None:
+    """Pattern keys are skipped when entities are rebuilt from the catalog."""
+    for appliance in (fridge, washer):
+        assert not [path for path in paths(appliance) if "*" in path]
+
+
+def test_static_attributes_do_not_duplicate_capabilities(fridge, washer, hob) -> None:
+    """An attribute advertised as a capability is only created once.
+
+    applianceMode is both a STATIC_ATTRIBUTES entry and a real capability on
+    several appliances, which used to produce two entities sharing one unique
+    id.
+    """
+    for appliance in (fridge, washer, hob):
+        unique_ids = [entity.unique_id for entity in appliance.entities]
+        assert len(unique_ids) == len(set(unique_ids))


### PR DESCRIPTION
## Proposed change

Adds support for Electrolux/AEG `HB` induction hobs, tested against an AEG
CCE84779CB (8000 ComboHob with integrated extractor). Meaningful Home Assistant
entities are added for hob status, cooking zones and the integrated extractor,
while device-reported capabilities remain the source of truth for what exists,
what is writable, which enum values are allowed and which numeric bounds apply.

The hob already produced entities on `main` — dynamic discovery handles the
nested `hobHood/*` and `hobZone*/*` containers as-is. What was missing was
correct semantics: durations had no device class or unit, a filter-saturation
indicator was exposed as a writable switch, a read-only lock was exposed as a
writable switch, and a value the appliance marks as non-selectable was being
offered in a dropdown. This PR fixes those and adds the metadata layer.

## Implementation

**Appliance-type catalogs.** Adds `CATALOG_APPLIANCE_TYPE`, keyed on the
`applianceInfo/applianceType` the appliance reports, layered between
`CATALOG_BASE` and `CATALOG_MODEL`. This resolves the existing
`# TODO: Use appliance_type as opposed to model?` in `api.py` without a broad
refactor — `Appliance.appliance_type` already existed. HB support is therefore
type-level, not model-level: no `if model == "CCE84779CB"` anywhere.

**Wildcard catalog keys.** A catalog key may use `*` in place of a container's
numeric suffix, e.g. `hobZone*/runningTime`. Lookup tries the exact path first,
then the wildcard form. This matters because the CCE84779CB reports zones
`hobZone1-4` **and** `hobZone7-8` (its bridged zones) with **no zone 5 or 6**,
and zones 7/8 expose five properties where zones 1-4 expose nine. Nothing may
assume a zone count, contiguous numbering, or a uniform property set. Wildcard
keys are patterns only and are never materialised as entities.

A wildcard entry's `friendly_name` carries an `{index}` placeholder, resolved
against the container number. Without it, `has_entity_name` would compose six
entities all called "Running time" on one device — distinguishable only by
`entity_id`, and identical in the UI, in search and to voice assistants. There
is a test asserting every entity name on the appliance is unique.

**Cooking controls are read-only.** The capability document inconsistently
reports a few cooking properties as `readwrite` —
`hobZone1/heatingQualitativeLevel`, `hobZone3/targetDuration`,
`hobModule1-2/procookLevel{Front,Rear}` — while the same properties on every
other zone are `read`. Combined with the appliance reporting
`remoteControl: NOT_SAFETY_RELEVANT_ENABLED`, that looks like a capability-document
inconsistency rather than a supported feature, so these are pinned to sensors.
`electrolux-group-developer-sdk` 0.6.1 corroborates this: `HbConfig`/`HBAppliance`
expose **no** cooking-level command at all — its entire writable HB surface is
hood fan speed, hood state, key sound tone, and child-lock *enable*. Reverting
this is a matter of dropping one `entity_platform` override per entry; the
reasoning is documented in `catalog_hob.py`.

**Child lock modelled safely.** `childLock` is advertised `readwrite` but
carries triggers that drop it to `access: read` once its value is `ENABLED`:

```json
"childLock": {"access": "readwrite", "type": "boolean",
  "triggers": [
    {"condition": {"operand_1": "value", "operand_2": "ENABLED",  "operator": "eq"},
     "action": {"$self": {"access": "read"}}},
    {"condition": {"operand_1": "value", "operand_2": "DISABLED", "operator": "eq"},
     "action": {"$self": {"access": "readwrite"}}}]}
```

So it cannot be disabled remotely, matching the official SDK's
`get_enable_child_lock_command` docstring: *"The child lock can be disabled only
manually."* It is exposed as a binary sensor rather than a switch, so the
integration never offers a turn-off the appliance will refuse. A remote *enable*
button is deliberately left for a follow-up: the button platform sends capability
value keys verbatim, and this capability needs a boolean payload, which needs its
own small change rather than riding along here.

**`uiLockMode` respects its access mode.** HB reports it as `access: read`, but
`CATALOG_BASE` models it as a writable switch for other appliance types. The HB
catalog overrides it back to a read-only binary sensor. Other appliance types are
untouched, and there is a regression test for that. Official HA core inverts this
same value for HB, so the `state_invert` here matches upstream.

**Disabled enum values are no longer selectable.** `hobToHoodState` marks
`AUTO_SUSPEND` as `{"disabled": true}`. Disabled values were excluded when the
select was built, but `current_option` re-added any unrecognised reported value
to the selectable list — so once the hob entered `AUTO_SUSPEND`, the dropdown
started offering it. This device enters that state routinely (observed at 08:43
and 09:10 on the test appliance). Only values the capability document explicitly
flags are withheld now, matching the SDK's `get_supported_hood_state`, which
filters on the same flag. Values the appliance reports but the document omits
are still learned and stay selectable — that fallback exists because Electrolux
documents are known to be incomplete, and withholding them would take away
settings that previously worked. `async_select_option` raises
`ServiceValidationError` for a flagged value rather than returning quietly, so a
script calling it sees the failure.

One wrinkle worth calling out for reviewers: `SelectEntity.state` returns `None`
when `current_option` is not in `options`, so simply filtering disabled values
out made a hob sitting in `AUTO_SUSPEND` render as `unknown` rather than showing
its real state. A disabled value is therefore kept in `options` *only while the
appliance is reporting it*, so the state stays truthful, while the write guard
prevents it ever being sent. There is a test asserting the rendered state and
not just the option list.

**Duplicate entity fix.** `applianceMode` is both a `STATIC_ATTRIBUTES` entry and
a real capability on this hob — and on the existing `EHE6899SA` sample — which
produced two entities sharing one unique id. Static attributes already advertised
as capabilities are now skipped.

**Extractor run-on duration is now in minutes.** Giving
`hobHood/targetDuration` a unit of seconds opts it into `ElectroluxNumber`'s
existing seconds↔minutes conversion, so the control changed from a raw
0–5940 s / step 60 slider to 0–99 min / step 1, converting back on write.
Better to use, but a deliberate behaviour change worth flagging.

**Fixtures and tests.** Adds sanitized `samples/CCE84779CB/` payloads (appliance
id, PNC and serial replaced; brand, model, appliance type, capability names, enum
values, access modes and bounds preserved) and a `tests/` suite of 51 tests that
builds appliances directly from the sample payloads. Non-HB appliances are
covered by regression tests using the existing `EHE6899SA` and `EW7F3816DB`
samples. Adds `requirements-test.txt` and a `Tests` workflow, since the repo
had no CI that would run them.

**Dev tooling.** `testAppliance.py` called `client.get_appliance_status()`, which
`pyelectroluxocp` 0.1.3 does not have, and omitted the now-required country code,
so it could not run at all. Rewritten to take credentials from the environment,
dump all four payloads per appliance, and tolerate appliances that 404 on
`/capabilities`.

## Entity model

75 entities on the test appliance. Writable: extractor fan speed, extractor
mode, hob-to-hood level, extractor run-on duration, key sound tone. Everything
else is read-only.

| Scope | Entities |
| :--- | :--- |
| Appliance | state, mode, alerts, remote control, key model, connectivity, link quality |
| Locks | child lock, control panel lock (both binary sensors) |
| Extractor | fan speed, mode, hob-to-hood level, run-on duration, time to end, window notification, charcoal filter |
| Per zone (×6) | power level, pot detection, residual heat, running time, time to end, target duration, reminder time, max power level, coil |
| Per module (×2) | heating module type, front/middle/rear zone, ProCook level front/rear |

Pot detection stays a four-state enum sensor (`NO_POT_IDLE`, `NO_POT_RUNNING`,
`POT_IDLE`, `POT_RUNNING`) rather than a binary sensor, since collapsing it would
discard whether the zone is running.

## Validation

Unit tests: 51 passing against the real captured payloads.

Physical device (AEG CCE84779CB, firmware `v1.9.2_hacl`):

- Discovered as one device, AEG / CCE84779CB, `applianceType: HB`,
  `deviceType: BUILT IN HOB`, `keyModel: Combo_DoubleFlexiBridge_4Zone_KM201.0.0`.
- Six zones discovered dynamically: 1, 2, 3, 4, 7, 8.
- Fan speed enum read from the device: `OFF, STEP_1, STEP_2, STEP_3, BREEZE,
  BOOST`. Note this model reports **no** `DRYING_CYCLE`, unlike the `peacock_hob`
  fixture on the official HA core branch — a good reason to keep enums
  device-driven.
- Hood state enum read from the device: `AUTOMATIC`, `MANUAL`, and
  `AUTO_SUSPEND` flagged disabled. `AUTO_SUSPEND` is not present in the upstream
  fixture either.
- **Write path confirmed on hardware.** Commanding
  `hobHood/hobToHoodFanSpeed = STEP_1` was accepted and reported back by the
  appliance within 2s; restoring `OFF` likewise. No API errors.
- **Push confirmed on hardware.** Those two changes appeared in Home Assistant
  at 11:30:25 and 11:30:37 against commands issued at 11:30:23 and 11:30:35 —
  roughly 2s, through the existing push mechanism, updating entity state without
  recreating entities. Physical changes made at the hob itself (`STEP_2`,
  `STEP_1`, `BREEZE`) were also tracked.
- Zone level, pot detection and residual heat verified read-only; no command was
  synthesized for them.

Verified in a running Home Assistant (2026.8, installed via HACS from this
branch), after restart:

- One device, `AEG CCE84779CB`, config entry preserved across the swap.
- All six zones present with the intended platforms, device classes, units and
  friendly names — e.g. `sensor.aeg_spisen_hobzone1_runningtime` is a `duration`
  sensor in `s`, `sensor.aeg_spisen_hobzone1_hobpotdetected` reads
  `No Pot Idle`, `binary_sensor.aeg_spisen_uilockmode` is a `lock`.
- Previously-writable cooking entities are now sensors; the old `number.*` and
  `switch.*` entities show as `unavailable`/`restored` as expected.
- `select.aeg_spisen_hobhood_hobtohoodstate` renders `Auto Suspend` while the
  appliance reports it, with `options` `["Automatic", "Manual", "Auto Suspend"]`;
  it drops back to two options once the appliance leaves that state.
- No errors or warnings attributable to the hob in the system log.

A real cooking session, captured end to end from the recorder (local time):

| Time | Entity | Change |
| :--- | :--- | :--- |
| 14:12:37.44 | Extractor mode | Auto Suspend → Automatic |
| 14:12:37.50 | Appliance state | Off → Idle |
| 14:12:38.00 | Appliance state / Zone 1 power | Idle → Running / 0 → 7 |
| 14:12:42.02 | Zone 1 pot detection | No Pot Idle → No Pot Running |
| 14:12:48.63 | Zone 1 pot detection | No Pot Running → **Pot Running** (pan placed) |
| 14:13:10.97 | Extractor fan speed | Off → Breeze |
| 14:13:12.92 | Extractor fan speed | Breeze → Off |
| 14:13:14.23 | Zone 1 power | 7 → 3 |
| 14:13:25.32 | Zone 2 power | 0 → 3 |
| 14:13:26.95 | Appliance state / Zones 1+2 | Running → **Paused** / both → 1 |
| 14:13:30.70 | Appliance state / Zones 1+2 | Paused → Running / both → 3 |
| 14:13:38.84 | Zone 1 running time | 0 → 60 s |
| 14:13:45.15-.61 | everything | → 0 / No Pot Idle / Off |

Every value is device-reported; nothing was commanded from Home Assistant. Points
worth noting:

- The four-state pot enum earns its keep: `No Pot Running` (zone on, no pan) is
  distinct from `Pot Running` six seconds later, and Zone 2 stayed
  `No Pot Running` throughout because nothing was placed on it. A binary sensor
  would have collapsed all of that.
- The appliance's Pause function is visible as `Paused` with every active zone
  dropping to level 1 and restoring on resume.
- `hobToHoodState` really does sit in `AUTO_SUSPEND` and flip in and out of it
  during normal use. It is recorded here as a genuine state, which is only true
  because of the disabled-value handling above — before that fix these periods
  rendered as `unknown`.
- Sub-second ordering across entities shows push latency is negligible, and no
  entity was recreated: there are no `unavailable`/`restored` transitions
  anywhere in the session.
- `residualHeatState` stayed `No` on both zones and still does. Expected rather
  than a defect: induction heats the pan, not the glass, and ~70 seconds is not
  long enough to warm the surface. Residual heat is confirmed working from
  earlier history on this appliance, where it steps `Low → Middle → High` and
  back over a longer cook.

## Notes for maintainers

- Correcting a capability's platform leaves the old entity orphaned in the
  registry (`restored: true`, state `unavailable`) for existing hob users, who
  need to delete them once. On the test appliance that is nine entities: three
  switches (`uiLockMode`, `childLock`, `hoodFilterCharcIndication` → binary
  sensors) and six numbers (`hobZone1/heatingQualitativeLevel`,
  `hobZone3/targetDuration`, `hobModule1-2/procookLevel{Front,Rear}` → sensors).
  Unavoidable when correcting a platform; flagging it for the release notes.
- `applianceState` is enabled by default for HB, but an existing installation
  has it already registered as disabled from `CATALOG_BASE`, and Home Assistant
  keeps the stored setting. Existing hob users need to enable it by hand once;
  new ones get it enabled.
- `hobZone*/hobCoil` is declared `type: number` but reported as `{}` by the
  appliance, so it has no displayable value. Disabled by default rather than
  blacklisted, since `ATTRIBUTES_BLACKLIST` is only applied to top-level
  capability keys and extending it to nested paths looked riskier than it was
  worth here.
- `hobModule*/bridgeMode` appears in the reported state but not in the capability
  document, so it gets no entity. Adding it would need a fixed
  `STATIC_ATTRIBUTES` path, which conflicts with dynamic module discovery.
- Two things this PR works around rather than fixes, both worth doing properly
  and neither hob-specific, so I left them out rather than widen the diff:
  a catalog entry cannot express "read-only" directly (it has to pin
  `entity_platform` to `SENSOR`, which also means a read-only *number* is
  inexpressible), and the capability walker does not parse `triggers`/`$self`,
  so conditional access is decided by hand per catalog key. The purifier
  payload quoted in `coordinator.py` uses the same `triggers` shape, so a
  walker that understood it would remove per-appliance guesswork generally.
  Happy to follow up on either if you'd like them.
- Two unrelated bugs found while capturing payloads, both triggered by an
  appliance that 404s on `/capabilities` (a PUREi9 robot vacuum here). They are
  on a separate branch, `fix/capability-error-handling`, to keep this PR scoped:
  `diagnostics.py` returns HTTP 500 for the whole account, and — more seriously —
  `coordinator.py` passes the exception to `_LOGGER.warning` with no format
  placeholder, so logging falls back to dumping the raw `ClientResponseError`
  whose repr includes the request headers, writing the account's
  `Authorization: Bearer` token into `home-assistant.log`. Happy to fold either
  into this PR if you would rather.
