### PR TITLE
Replace deprecated concentration constants with unit enums

### DIFF
--- a/custom_components/electrolux_status/catalog_purifier.py
+++ b/custom_components/electrolux_status/catalog_purifier.py
@@ -3,10 +3,9 @@
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_PARTS_PER_BILLION,
-    CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
+    UnitOfDensity,
+    UnitOfRatio,
     UnitOfTemperature,
 )
 from homeassistant.helpers.entity import EntityCategory
@@ -28,31 +27,31 @@ A9 = {
     ),
     "PM1": ElectroluxDevice(
         device_class=SensorDeviceClass.PM1,
-        unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        unit=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
         entity_category=None,
         friendly_name="PM1",
     ),
     "PM2_5": ElectroluxDevice(
         device_class=SensorDeviceClass.PM25,
-        unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        unit=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
         entity_category=None,
         friendly_name="PM2.5",
     ),
     "PM10": ElectroluxDevice(
         device_class=SensorDeviceClass.PM10,
-        unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        unit=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
         entity_category=None,
         friendly_name="PM10",
     ),
     "TVOC": ElectroluxDevice(
         device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS,
-        unit=CONCENTRATION_PARTS_PER_BILLION,
+        unit=UnitOfRatio.PARTS_PER_BILLION,
         entity_category=None,
         friendly_name="TVOC",
     ),
     "ECO2": ElectroluxDevice(
         device_class=SensorDeviceClass.CO2,
-        unit=CONCENTRATION_PARTS_PER_MILLION,
+        unit=UnitOfRatio.PARTS_PER_MILLION,
         entity_category=None,
         friendly_name="eCO2",
     ),

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Electrolux Status",
   "hacs": "1.33.0",
-  "homeassistant": "2024.1.2"
+  "homeassistant": "2026.7.0"
 }


### PR DESCRIPTION
## What

Home Assistant 2026.8 emits deprecation warnings for three constants used by the purifier (A9) catalog, all scheduled for removal in HA Core 2027.8:

| Deprecated constant | Replacement (HA 2026.7+) |
| --- | --- |
| `CONCENTRATION_MICROGRAMS_PER_CUBIC_METER` | `UnitOfDensity.MICROGRAMS_PER_CUBIC_METER` |
| `CONCENTRATION_PARTS_PER_BILLION` | `UnitOfRatio.PARTS_PER_BILLION` |
| `CONCENTRATION_PARTS_PER_MILLION` | `UnitOfRatio.PARTS_PER_MILLION` |

## Changes

- `catalog_purifier.py`: switch to the `UnitOfDensity` / `UnitOfRatio` enums. The members resolve to identical unit strings (`μg/m³`, `ppb`, `ppm`), so there is no change to entity state or unit of measurement.
- `hacs.json`: raise the minimum Home Assistant version to `2026.7.0`, the release that introduced `UnitOfDensity` and `UnitOfRatio`.

## Compatibility note

`UnitOfDensity` / `UnitOfRatio` do not exist before HA 2026.7, hence the `hacs.json` bump. If retaining support for older HA is preferred, an alternative is a `try/except ImportError` fallback to the old constants (not removed until 2027.8) rather than raising the minimum.

Fixes #213
